### PR TITLE
chore: ~から始まる一時ファイルをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ npm-debug.log*
 # Temporary files
 *.tmp
 *.temp
+~*
 
 # Test coverage
 coverage/


### PR DESCRIPTION
## Summary
- UiPathなどで自動生成される`~`から始まる一時ファイル（`~Main.xaml`等）をGitの追跡対象から除外
- `.gitignore`に`~*`パターンを追加

## Test plan
- [ ] `.gitignore`に`~*`が追加されていることを確認
- [ ] `~Main.xaml`などのファイルが無視されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)