### PR TITLE
docs: 作業完了フローにユーザー確認とPR承認手順を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,19 +70,30 @@
 ```bash
 # 1. PRを作成
 gh pr create --title "機能追加: XAMLビジュアライザー改善" --body "詳細な変更内容"
+# 出力例: https://github.com/AutoFor/uipath-xaml-visualizer/pull/44
 
 # 2. イシューを作成
 gh issue create --title "XAMLビジュアライザーの表示改善" --body "背景と目的"
+# 出力例: https://github.com/AutoFor/uipath-xaml-visualizer/issues/45
 
 # 3. PRとイシューを紐づけ（PRの本文に追記）
-gh pr edit <PR番号> --body "変更内容\n\nCloses #<イシュー番号>"
+gh pr edit 44 --body "変更内容\n\nCloses #45"
 
-# 4. masterブランチに戻る
+# 4. ユーザーに確認
+# → Claudeがユーザーに「PRとイシューを確認してください。問題なければ承認します。」と聞く
+
+# 5. PR承認とマージ（ユーザー承認後）
+gh pr merge 44 --squash
+
+# 6. イシュークローズ（通常は自動だが念のため）
+gh issue close 45
+
+# 7. masterブランチに戻る
 git checkout master
 
-# 5. 最新状態を取得
-git fetch
+# 8. 最新状態を取得と不要ブランチ削除
 git pull
+git fetch --prune
 ```
 
 ---


### PR DESCRIPTION
## 変更内容

GitHub運用ルールの「作業完了後の必須手順」を更新し、より確実な品質管理フローを追加しました。

### 追加した手順

**4. ユーザーに確認を依頼**
- PRとイシューの内容に問題がないか確認を求める
- ユーザーの承認を待つ

**5. PR承認とマージ**（ユーザー承認後）
- `gh pr merge` コマンドでPRをマージ
- `--squash`, `--merge`, `--rebase` のオプション選択

**6. イシュークローズ**
- `gh issue close` コマンドで明示的にクローズ
- 注: `Closes #XX` があれば自動クローズされる

**7. masterブランチに戻る**
- 作業ブランチからmasterに切り替え

**8. リモートの最新状態を取得と不要ブランチ削除**
- `git pull` でリモートの最新を取得
- `git fetch --prune` で削除されたリモートブランチを同期

### 完了フローの例

具体的なコマンド例を追記し、実際の使用方法を明示しました。

### 期待される効果

- ユーザーによる最終確認が入るため、品質が向上
- PR承認とマージが明示的に行われる
- 不要なブランチが自動削除され、リポジトリがクリーンに保たれる

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>