### PR TITLE
docs: Claude Code Skillsを追加しプロジェクトルールを整備

### DIFF
--- a/.claude/skills/git-worktree-branch/SKILL.md
+++ b/.claude/skills/git-worktree-branch/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: git-worktree-branch
+description: UiPath XAML Visualizer プロジェクトで新しい作業を開始するときの Git ブランチ運用。ユーザーが「新しい機能を追加したい」「バグを修正したい」「作業を開始したい」「ブランチを作成したい」と言ったときに使用します。
+disable-model-invocation: false
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Git Worktree ブランチ運用スキル
+
+このスキルは、`uipath-github-xaml-visualizer` プロジェクトで新しい作業を開始するときの標準手順を提供します。
+
+## ⚠️ 重要な禁止事項
+
+- **master ブランチで直接コード修正を行わない**
+- **master ブランチで `git commit` や `git push` を提案しない**
+- 改修作業を開始する前に、必ず新しいブランチを作成する
+
+## 作業開始手順
+
+### 1. 作業内容の確認
+
+ユーザーに以下を確認する：
+- 今回の作業内容は何か？
+- 機能追加なのか、バグ修正なのか？
+
+### 2. ブランチ名の提案
+
+作業内容に応じて、以下の命名規則でブランチ名を1つ提案する：
+
+- 機能追加の場合: `feature/機能名`
+  - 例: `feature/add-xaml-preview`, `feature/improve-parser`
+- バグ修正の場合: `fix/修正内容`
+  - 例: `fix/parse-error`, `fix/display-issue`
+
+### 3. Git Worktree コマンドの提案
+
+以下の形式で `git worktree add` コマンドを提案する：
+
+```bash
+git worktree add ../uipath-xaml-visualizer-<ブランチ種別> <ブランチ名>
+```
+
+**具体例:**
+```bash
+# 機能追加の場合
+git worktree add ../uipath-xaml-visualizer-feature feature/add-xaml-preview
+
+# バグ修正の場合
+git worktree add ../uipath-xaml-visualizer-fix fix/parse-error
+```
+
+**Worktree の仕組み説明:**
+- メインリポジトリと同じ階層に新しいディレクトリが作成される
+- 新しいブランチが自動的に作成され、そのブランチにチェックアウトされる
+- Worktree ディレクトリ名: `uipath-xaml-visualizer-{ブランチ種別}`
+
+### 4. 作業ディレクトリへの移動
+
+Worktree ディレクトリへの移動コマンドを提案する：
+
+```bash
+cd ../uipath-xaml-visualizer-<ブランチ種別>
+```
+
+### 5. 作業完了後の手順を案内
+
+作業完了後に必要な手順を必ず案内する：
+
+1. **コミット**: 変更をコミット
+2. **プッシュ**: リモートリポジトリにプッシュ
+   ```bash
+   git push -u origin <ブランチ名>
+   ```
+3. **PR 作成**: GitHub でプルリクエストを作成（`/github-finish` スキルを使用）
+4. **Issue 作成と紐付け**: PR と Issue を関連付け
+5. **Worktree 削除**: PR マージ後にWorktreeを削除
+   ```bash
+   # メインリポジトリに戻る
+   cd ../uipath-github-xaml-visualizer
+
+   # Worktree を削除
+   git worktree remove ../uipath-xaml-visualizer-<ブランチ種別>
+   ```
+
+## Worktree のメリット
+
+ユーザーに以下のメリットを説明する：
+
+- ✅ ブランチ切り替え時のファイル変更が不要
+- ✅ ビルドや node_modules 再構築が不要
+- ✅ 緊急対応が入っても作業中のコードを退避する必要がない
+- ✅ 複数の作業を並行して進められる
+
+## 注意事項
+
+- Worktreeを削除する前にコミット・プッシュを忘れずに行う
+- `.git` フォルダは元のリポジトリで共有される
+- PRマージ後は忘れずにWorktreeを削除する
+
+## 例外: Worktree を使わなくてもよいケース
+
+以下の場合は通常の `git checkout -b` でも可：
+- ドキュメントの軽微な修正（README.md、CLAUDE.mdなど）
+- 設定ファイルの更新（.claude/settings.local.jsonなど）
+
+## Worktree 一覧の確認
+
+必要に応じて、以下のコマンドで現在のWorktree一覧を確認できることを案内する：
+
+```bash
+git worktree list
+```

--- a/.claude/skills/github-finish/SKILL.md
+++ b/.claude/skills/github-finish/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: github-finish
+description: UiPath XAML Visualizer プロジェクトで作業（テーマ）完了時に行う GitHub PR と Issue の標準フロー。ユーザーが「作業が完了した」「PRを作成したい」「テーマが終わった」と言ったときに使用します。
+disable-model-invocation: false
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - mcp__github__create_pull_request
+  - mcp__github__issue_write
+  - mcp__github__update_pull_request
+  - mcp__github__merge_pull_request
+  - mcp__github__get_me
+---
+
+# GitHub 作業完了フロースキル
+
+このスキルは、`uipath-github-xaml-visualizer` プロジェクトで作業（テーマ）が完了したときの標準的な GitHub 運用手順を提供します。
+
+## 前提条件の確認
+
+以下を確認してから手順を開始する：
+
+- ✅ 作業ブランチに必要なコミットがすべて含まれている
+- ✅ リモートリポジトリに `git push` 済みである
+- ✅ コードが正常に動作する
+
+## 作業完了後の必須手順
+
+**必ず以下の順序で実行する：**
+
+### 1. プルリクエスト（PR）作成
+
+GitHub の MCP ツールまたは `gh` コマンドで PR を作成する。
+
+**MCPツール使用例:**
+```
+mcp__github__create_pull_request を使用
+- owner: AutoFor
+- repo: uipath-xaml-visualizer
+- title: [作業内容を簡潔に記載]
+- body: [変更内容の詳細]
+- head: [作業ブランチ名]
+- base: master
+```
+
+**gh コマンド例:**
+```bash
+gh pr create --title "機能追加: XAMLビジュアライザー改善" --body "詳細な変更内容"
+```
+
+**PR作成時のポイント:**
+- タイトルは簡潔で分かりやすく（50文字以内推奨）
+- 本文には変更の背景、実装内容、テスト結果を記載
+- スクリーンショットやコード例があれば追加
+
+### 2. イシュー（Issue）作成
+
+作業テーマに対するイシューを作成する。
+
+**MCPツール使用例:**
+```
+mcp__github__issue_write を使用
+- method: create
+- owner: AutoFor
+- repo: uipath-xaml-visualizer
+- title: [作業テーマを記載]
+- body: [作業の目的や背景を記載]
+```
+
+**gh コマンド例:**
+```bash
+gh issue create --title "XAMLビジュアライザーの表示改善" --body "背景と目的"
+```
+
+**Issue作成時のポイント:**
+- タイトルは作業テーマを明確に
+- 本文には目的、背景、期待される成果を記載
+
+### 3. PR と Issue を紐づけ
+
+PR の本文に `Closes #イシュー番号` を追加して、PR と Issue を関連付ける。
+
+**MCPツール使用例:**
+```
+mcp__github__update_pull_request を使用
+- owner: AutoFor
+- repo: uipath-xaml-visualizer
+- pullNumber: [PR番号]
+- body: "変更内容...\n\nCloses #[Issue番号]"
+```
+
+**gh コマンド例:**
+```bash
+gh pr edit <PR番号> --body "変更内容
+
+Closes #<Issue番号>"
+```
+
+**紐付けのメリット:**
+- PR がマージされると Issue が自動でクローズされる
+- 変更履歴と課題が明確に関連付けられる
+
+### 4. ユーザーに確認を依頼
+
+**以下の確認文をユーザーに提示する:**
+
+```
+作業完了フローを実行しました：
+
+📋 プルリクエスト: #[PR番号]
+🎯 イシュー: #[Issue番号]
+
+以下の内容をご確認ください：
+- PR のタイトルと本文は適切か？
+- Issue の内容は正確か？
+- PR と Issue の紐付けは正しいか？
+
+問題なければ、PR の承認とマージを行います。
+よろしいですか？
+```
+
+**ユーザーの承認を待つこと。**
+
+### 5. PR 承認とマージ（ユーザー承認後のみ）
+
+ユーザーの承認を得てから、PR をマージする。
+
+**MCPツール使用例:**
+```
+mcp__github__merge_pull_request を使用
+- owner: AutoFor
+- repo: uipath-xaml-visualizer
+- pullNumber: [PR番号]
+- merge_method: squash  # または merge, rebase
+```
+
+**gh コマンド例:**
+```bash
+gh pr merge <PR番号> --squash  # または --merge, --rebase
+```
+
+**マージ方法の選択:**
+- `--squash`: 複数コミットを1つにまとめる（推奨）
+- `--merge`: マージコミットを作成
+- `--rebase`: コミット履歴を線形に保つ
+
+### 6. Issue クローズ
+
+PR に `Closes #XX` が含まれていれば自動でクローズされるが、念のため確認する。
+
+**手動クローズが必要な場合:**
+```bash
+gh issue close <Issue番号>
+```
+
+### 7. master ブランチに戻る
+
+作業ブランチから master ブランチに戻る。
+
+```bash
+cd ../uipath-github-xaml-visualizer  # メインリポジトリに戻る（Worktree使用時）
+git checkout master
+```
+
+### 8. リモートの最新状態を取得と不要ブランチ削除
+
+master ブランチを最新に更新し、不要なリモートブランチ情報を削除する。
+
+```bash
+git pull
+git fetch --prune
+```
+
+### 9. Worktree の削除（Worktree使用時のみ）
+
+Git Worktree を使用していた場合、作業ディレクトリを削除する。
+
+```bash
+git worktree remove ../uipath-xaml-visualizer-<ブランチ種別>
+```
+
+**例:**
+```bash
+git worktree remove ../uipath-xaml-visualizer-feature
+```
+
+## 完了フローの実行例
+
+```bash
+# 1. PRを作成
+gh pr create --title "機能追加: XAMLビジュアライザー改善" --body "詳細な変更内容"
+# 出力例: https://github.com/AutoFor/uipath-xaml-visualizer/pull/44
+
+# 2. イシューを作成
+gh issue create --title "XAMLビジュアライザーの表示改善" --body "背景と目的"
+# 出力例: https://github.com/AutoFor/uipath-xaml-visualizer/issues/45
+
+# 3. PRとイシューを紐づけ（PRの本文に追記）
+gh pr edit 44 --body "変更内容
+
+Closes #45"
+
+# 4. ユーザーに確認
+# → 「PRとイシューを確認してください。問題なければ承認します。」
+
+# 5. PR承認とマージ（ユーザー承認後）
+gh pr merge 44 --squash
+
+# 6. Issueクローズ（通常は自動だが念のため）
+gh issue close 45
+
+# 7. masterブランチに戻る
+git checkout master
+
+# 8. 最新状態を取得と不要ブランチ削除
+git pull
+git fetch --prune
+
+# 9. Worktreeを削除（使用時のみ）
+git worktree remove ../uipath-xaml-visualizer-feature
+```
+
+## 注意事項
+
+- **必ずユーザーの承認を得てから PR をマージする**
+- PR と Issue の内容は慎重に確認する
+- Worktree を削除する前にコミット・プッシュが完了しているか確認
+- `git fetch --prune` でリモートで削除されたブランチをローカルからも削除
+
+## よくある質問
+
+**Q: PR と Issue はどちらを先に作るべきか？**
+A: PR を先に作成してから Issue を作成し、PR に `Closes #XX` で紐付けます。
+
+**Q: マージ方法は何を選ぶべきか？**
+A: 基本的には `--squash` を使用して、コミット履歴を整理します。
+
+**Q: Worktree を削除し忘れたらどうなるか？**
+A: `git worktree list` で確認し、`git worktree remove` で削除できます。

--- a/.claude/skills/japanese-comments/SKILL.md
+++ b/.claude/skills/japanese-comments/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: japanese-comments
+description: TypeScript/JavaScript コードに日本語の行末コメントを追加する。ユーザーが「コードを書いて」「関数を作成して」「実装して」と言ったときに自動適用します。
+disable-model-invocation: false
+user-invocable: true
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+---
+
+# 日本語コメント追加スキル
+
+このスキルは、UiPath XAML Visualizer プロジェクトのコーディング規約に従い、TypeScript/JavaScript コードに日本語の行末コメントを追加します。
+
+## コメント追加のルール
+
+### 基本方針
+
+1. **すべての重要な行に日本語コメントを追加する**
+   - 関数/メソッドの宣言
+   - 変数の宣言（特に重要なもの）
+   - 制御構文（if, for, while など）
+   - 重要なロジック
+
+2. **初心者にも理解できる平易な説明を書く**
+   - 専門用語は避けるか、説明を加える
+   - 「何をしているか」を明確に
+   - 「なぜそうするのか」も可能な限り説明
+
+3. **行末コメントを使用する**
+   - コードの右側にコメントを配置
+   - コードとコメントのバランスを保つ
+
+## コメントの書き方例
+
+### ✅ 良い例
+
+```typescript
+function parseXaml(content: string): XamlNode {  // XAML文字列を解析してノードツリーを生成
+    const parser = new DOMParser();  // XMLパーサーを初期化
+    const doc = parser.parseFromString(content, "text/xml");  // 文字列をXMLドキュメントに変換
+
+    if (doc.querySelector("parsererror")) {  // パースエラーが発生した場合
+        throw new Error("無効なXAML形式です");  // エラーをスロー
+    }
+
+    return buildNodeTree(doc.documentElement);  // ドキュメント要素からノードツリーを構築
+}
+
+const PORT = 3000;  // プレビューサーバーのポート番号
+const rootElement = document.getElementById("root");  // ルート要素を取得
+
+for (let i = 0; i < nodes.length; i++) {  // すべてのノードを順番に処理
+    processNode(nodes[i]);  // ノードを処理
+}
+```
+
+### ❌ 悪い例
+
+```typescript
+// この関数はXAMLをパースします
+function parseXaml(content: string): XamlNode {
+    const parser = new DOMParser();
+    // パース
+    const doc = parser.parseFromString(content, "text/xml");
+
+    // エラーチェック
+    if (doc.querySelector("parsererror")) {
+        throw new Error("無効なXAML形式です");
+    }
+
+    return buildNodeTree(doc.documentElement);
+}
+```
+
+## コメントのパターン
+
+### 1. 関数/メソッドの宣言
+
+```typescript
+function calculateSize(width: number, height: number): number {  // 幅と高さから面積を計算
+    return width * height;  // 幅×高さを返す
+}
+
+async function loadFile(path: string): Promise<string> {  // ファイルを非同期で読み込む
+    const content = await fs.readFile(path, "utf-8");  // UTF-8形式でファイル内容を取得
+    return content;  // ファイル内容を返す
+}
+```
+
+### 2. 変数の宣言
+
+```typescript
+const MAX_DEPTH = 10;  // ノードツリーの最大深度
+let currentIndex = 0;  // 現在処理中のインデックス
+const isValid = checkValidity();  // 入力値の妥当性を確認
+```
+
+### 3. 制御構文
+
+```typescript
+if (node.children.length > 0) {  // 子ノードが存在する場合
+    processChildren(node.children);  // 子ノードを再帰的に処理
+}
+
+for (const child of node.children) {  // すべての子ノードを順番に処理
+    renderChild(child);  // 子ノードをレンダリング
+}
+
+while (queue.length > 0) {  // キューが空になるまで処理を続ける
+    const item = queue.shift();  // キューから先頭要素を取り出す
+    processItem(item);  // 要素を処理
+}
+```
+
+### 4. 条件分岐
+
+```typescript
+const result = isValid  // 妥当性に応じて結果を決定
+    ? "成功"  // 妥当な場合は成功
+    : "失敗";  // 無効な場合は失敗
+```
+
+### 5. オブジェクト/配列の定義
+
+```typescript
+const config = {
+    port: 3000,  // サーバーポート
+    host: "localhost",  // ホスト名
+    debug: true  // デバッグモードの有効化
+};
+
+const colors = [
+    "#FF0000",  // 赤
+    "#00FF00",  // 緑
+    "#0000FF"   // 青
+];
+```
+
+## コメントを省略してもよいケース
+
+以下の場合は、コメントを省略しても構いません：
+
+1. **自明な処理**
+   ```typescript
+   const sum = a + b;  // コメント不要（明らかに足し算）
+   ```
+
+2. **一時変数（スコープが狭い）**
+   ```typescript
+   const temp = value;  // 一時的な値の保持
+   ```
+
+3. **単純な return 文**
+   ```typescript
+   return true;  // コメント不要（明らかに真を返す）
+   ```
+
+## 実装時の注意事項
+
+### コードを新規作成する場合
+
+- 最初から日本語コメントを含めてコードを生成する
+- コメントとコードを同時に書く
+
+### 既存コードを編集する場合
+
+- 新しく追加する行には必ず日本語コメントを付ける
+- 既存のコメントがない行を編集する場合、コメントを追加する
+- 既存のコメントがある行は、そのコメントを更新する
+
+### コメントの長さ
+
+- 1行あたり最大50文字程度を目安にする
+- 長い説明が必要な場合は、複数行に分割するか、関数の前にブロックコメントを追加
+
+```typescript
+/**
+ * XAML文字列を解析してノードツリーを生成する関数
+ * @param content - 解析するXAML文字列
+ * @returns 生成されたノードツリー
+ * @throws パースエラーが発生した場合、Errorをスロー
+ */
+function parseXaml(content: string): XamlNode {  // XAML文字列を解析
+    // ... 実装
+}
+```
+
+## チェックリスト
+
+コード作成・編集時に以下を確認する：
+
+- [ ] すべての関数/メソッドに日本語コメントがある
+- [ ] 重要な変数宣言に日本語コメントがある
+- [ ] 制御構文（if, for, while）に日本語コメントがある
+- [ ] コメントは初心者にも理解できる平易な日本語である
+- [ ] コメントは行末に配置されている
+- [ ] コメントとコードのバランスが適切である
+
+## 適用例
+
+### 変更前
+
+```typescript
+function renderNode(node: XamlNode) {
+    const element = document.createElement("div");
+    element.className = "node";
+    element.textContent = node.name;
+
+    if (node.children) {
+        for (const child of node.children) {
+            const childElement = renderNode(child);
+            element.appendChild(childElement);
+        }
+    }
+
+    return element;
+}
+```
+
+### 変更後
+
+```typescript
+function renderNode(node: XamlNode) {  // XAMLノードをDOM要素としてレンダリング
+    const element = document.createElement("div");  // 新しいdiv要素を作成
+    element.className = "node";  // ノード用のCSSクラスを設定
+    element.textContent = node.name;  // ノード名をテキストとして表示
+
+    if (node.children) {  // 子ノードが存在する場合
+        for (const child of node.children) {  // すべての子ノードを順番に処理
+            const childElement = renderNode(child);  // 子ノードを再帰的にレンダリング
+            element.appendChild(childElement);  // レンダリングした子要素を追加
+        }
+    }
+
+    return element;  // 作成したDOM要素を返す
+}
+```
+
+## まとめ
+
+- **すべてのコードに日本語の行末コメントを追加**
+- **初心者にも理解できる平易な説明**
+- **「何をしているか」を明確に記述**
+- **自明な処理以外はコメント必須**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,155 +1,78 @@
 # UiPath XAML Visualizer プロジェクトルール
 
-## 🔒 Git ブランチ運用ルール
+## 📚 Claude Code Skills について
 
-### ⚠️ masterブランチでの直接作業禁止
+このプロジェクトでは、繰り返し実行される作業を **Claude Code Skills** として定義しています。
+
+### 利用可能なスキル
+
+| スキル名 | 説明 | 呼び出し方法 |
+|---------|------|------------|
+| `/git-worktree-branch` | Git Worktree を使った新規ブランチ作成 | 「新しい機能を追加したい」「作業を開始したい」 |
+| `/github-finish` | 作業完了時の PR・Issue 作成フロー | 「作業が完了した」「PRを作成したい」 |
+| `/japanese-comments` | TypeScript/JavaScript コードに日本語コメント追加 | 「コードを書いて」「実装して」 |
+
+### スキルの場所
+
+スキルは [.claude/skills/](.claude/skills/) ディレクトリに保存されています。
+
+- [.claude/skills/git-worktree-branch/SKILL.md](.claude/skills/git-worktree-branch/SKILL.md)
+- [.claude/skills/github-finish/SKILL.md](.claude/skills/github-finish/SKILL.md)
+- [.claude/skills/japanese-comments/SKILL.md](.claude/skills/japanese-comments/SKILL.md)
+
+## 🔒 Git ブランチ運用ルール（概要）
+
+詳細は `/git-worktree-branch` スキルを参照してください。
+
+### ⚠️ 重要な原則
 - **masterブランチで直接コード修正を行わない**
 - 改修作業を開始する前に、必ず新しいブランチを作成する
 - ブランチ名の命名規則: `feature/機能名` または `fix/修正内容`
 
-### 作業フロー
+### 基本フロー
 
-1. **Git Worktree でブランチ作成**
-   ```bash
-   git worktree add ../uipath-xaml-visualizer-feature feature/機能名
-   # または
-   git worktree add ../uipath-xaml-visualizer-fix fix/修正内容
-   ```
-   - メインリポジトリと同じ階層に新しいディレクトリが作成される
-   - 新しいブランチが自動的に作成され、そのブランチにチェックアウトされる
-   - Worktree ディレクトリ名の命名規則: `uipath-xaml-visualizer-{ブランチ名}`
+1. Git Worktree でブランチ作成
+2. Worktree ディレクトリに移動
+3. コード修正
+4. コミット & プッシュ
+5. プルリクエスト & Issue 作成
+6. PR マージ後に Worktree 削除
 
-2. **Worktree ディレクトリに移動**
-   ```bash
-   cd ../uipath-xaml-visualizer-feature
-   ```
-
-3. **コード修正**: 新しいWorktree内で作業
-
-4. **コミット**: 変更をコミット
-
-5. **プッシュ**: リモートリポジトリにプッシュ
-   ```bash
-   git push -u origin feature/機能名
-   ```
-
-6. **プルリクエスト**: masterブランチへのマージはPR経由で行う
-
-7. **作業完了後、メインリポジトリに戻る**
-   ```bash
-   cd ../uipath-github-xaml-visualizer
-   ```
-
-8. **Worktree を削除**（PR マージ後）
-   ```bash
-   git worktree remove ../uipath-xaml-visualizer-feature
-   ```
-
-9. **Worktree 一覧を確認**（必要に応じて）
-   ```bash
-   git worktree list
-   ```
-
-#### Worktree のメリット
-- ブランチ切り替え時のファイル変更が不要
-- ビルドやnode_modules再構築が不要
-- 緊急対応が入っても作業中のコードを退避する必要がない
-- 複数の作業を並行して進められる
-
-#### 注意事項
-- Worktreeを削除する前にコミット・プッシュを忘れずに
-- `.git` フォルダは元のリポジトリで共有される
-- PRマージ後は忘れずにWorktreeを削除する
-
-### 例外
-- ドキュメントの軽微な修正（README.md、CLAUDE.mdなど）は通常の `git checkout -b` でも可
-- 設定ファイルの更新（.claude/settings.local.jsonなど）は通常の `git checkout -b` でも可
+**📌 詳細な手順は `/git-worktree-branch` スキルで確認できます。**
 
 ---
 
-## 📋 GitHub運用ルール
+## 📋 GitHub運用ルール（概要）
 
-### 作業完了後の必須手順（テーマ完了時）
+詳細は `/github-finish` スキルを参照してください。
 
-作業（テーマ）が完了したら、**必ず以下の順序で実行**する：
+### 作業完了後の必須手順
 
-1. **プルリクエスト作成**
-   - `gh pr create` コマンドでPRを作成
-   - タイトル: 作業内容を簡潔に記載
-   - 本文: 変更内容の詳細を記載
+作業（テーマ）が完了したら、以下の順序で実行：
 
-2. **イシュー作成**
-   - `gh issue create` コマンドでイシューを作成
-   - タイトル: 作業テーマを記載
-   - 本文: 作業の目的や背景を記載
+1. プルリクエスト作成
+2. イシュー作成
+3. PR と Issue を紐づけ
+4. ユーザーに確認を依頼
+5. PR 承認とマージ（ユーザー承認後）
+6. Issue クローズ
+7. master ブランチに戻る
+8. リモートの最新状態を取得
 
-3. **PRとイシューを紐づけ**
-   - PRの本文に `Closes #イシュー番号` を追加
-   - `gh pr edit <PR番号> --body` で編集
-
-4. **ユーザーに確認を依頼**
-   - PRとイシューの内容に問題がないか確認を求める
-   - ユーザーの承認を待つ
-
-5. **PR承認とマージ**（ユーザー承認後）
-   ```bash
-   gh pr merge <PR番号> --squash  # または --merge, --rebase
-   ```
-
-6. **イシュークローズ**
-   ```bash
-   gh issue close <イシュー番号>
-   ```
-   - 注意: PRに `Closes #XX` が含まれていれば自動でクローズされる
-
-7. **masterブランチに戻る**
-   ```bash
-   git checkout master
-   ```
-
-8. **リモートの最新状態を取得と不要ブランチ削除**
-   ```bash
-   git pull
-   git fetch --prune
-   ```
-
-### 完了フローの例
-```bash
-# 1. PRを作成
-gh pr create --title "機能追加: XAMLビジュアライザー改善" --body "詳細な変更内容"
-# 出力例: https://github.com/AutoFor/uipath-xaml-visualizer/pull/44
-
-# 2. イシューを作成
-gh issue create --title "XAMLビジュアライザーの表示改善" --body "背景と目的"
-# 出力例: https://github.com/AutoFor/uipath-xaml-visualizer/issues/45
-
-# 3. PRとイシューを紐づけ（PRの本文に追記）
-gh pr edit 44 --body "変更内容\n\nCloses #45"
-
-# 4. ユーザーに確認
-# → Claudeがユーザーに「PRとイシューを確認してください。問題なければ承認します。」と聞く
-
-# 5. PR承認とマージ（ユーザー承認後）
-gh pr merge 44 --squash
-
-# 6. イシュークローズ（通常は自動だが念のため）
-gh issue close 45
-
-# 7. masterブランチに戻る
-git checkout master
-
-# 8. 最新状態を取得と不要ブランチ削除
-git pull
-git fetch --prune
-```
+**📌 詳細な手順とコマンド例は `/github-finish` スキルで確認できます。**
 
 ---
 
-## 💻 開発ルール
+## 💻 開発ルール（概要）
+
+詳細は `/japanese-comments` スキルを参照してください。
 
 ### コーディング規約
-- TypeScript/JavaScriptコードには日本語コメントを追加
+- TypeScript/JavaScriptコードには日本語の行末コメントを追加
 - 初心者にも理解できる平易な説明を心がける
+- すべての重要な行にコメントを付ける
+
+**📌 コメントの書き方とパターンは `/japanese-comments` スキルで確認できます。**
 
 ### ファイル構造
 ```


### PR DESCRIPTION
## 概要
繰り返し実行される作業をClaude Code Skillsとして定義し、プロジェクトルールを整備しました。

## 変更内容

### 新規追加
- `.claude/skills/git-worktree-branch/SKILL.md`: Git Worktreeを使ったブランチ作成フロー
- `.claude/skills/github-finish/SKILL.md`: 作業完了時のPR・Issue作成フロー
- `.claude/skills/japanese-comments/SKILL.md`: TypeScript/JavaScriptコードへの日本語コメント追加ルール

### 更新
- `CLAUDE.md`: スキルの説明を追加し、プロジェクトルールを整理

## スキルの内容

### 1. git-worktree-branch
- Git Worktreeを使った並行作業環境の構築
- masterブランチを保護しながら安全に作業
- ブランチ作成から削除までの標準フロー

### 2. github-finish
- 作業完了時の標準手順
- PR作成 → Issue作成 → 紐づけ → マージ → クリーンアップ
- ユーザー確認とPR承認のワークフロー

### 3. japanese-comments
- TypeScript/JavaScriptコードへの日本語コメント追加
- 初心者にも理解できる平易な説明
- コメントの書き方とパターン

## 効果
- 作業の標準化により品質向上
- 繰り返し作業の効率化
- 新規メンバーのオンボーディング支援

## テスト計画
- [x] 各スキルファイルの内容確認
- [x] CLAUDE.mdの記載内容確認
- [ ] 実際にスキルを使用してワークフローを検証

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)