### PR TITLE
fix: レンダラーの絵文字アイコンをテキストラベルに変更

### DIFF
--- a/packages/shared/renderer/diff-renderer.ts
+++ b/packages/shared/renderer/diff-renderer.ts
@@ -132,7 +132,7 @@ export class DiffRenderer {
 
     const header = document.createElement('div');
     header.className = 'screenshot-header';
-    header.textContent = '📷 Screenshot 変更:';
+    header.textContent = 'Screenshot 変更:';
 
     const compareContainer = document.createElement('div');
     compareContainer.className = 'compare-container';
@@ -187,9 +187,9 @@ export class DiffRenderer {
    */
   private getDiffBadge(diffType: DiffType): string {
     const badgeMap: Record<DiffType, string> = {
-      [DiffType.ADDED]: '<span class="badge badge-added">🆕 追加</span>',
-      [DiffType.REMOVED]: '<span class="badge badge-removed">🗑️ 削除</span>',
-      [DiffType.MODIFIED]: '<span class="badge badge-modified">🟡 変更</span>'
+      [DiffType.ADDED]: '<span class="badge badge-added">+ 追加</span>',
+      [DiffType.REMOVED]: '<span class="badge badge-removed">- 削除</span>',
+      [DiffType.MODIFIED]: '<span class="badge badge-modified">~ 変更</span>'
     };
 
     return badgeMap[diffType];
@@ -200,21 +200,21 @@ export class DiffRenderer {
    */
   private getActivityIcon(type: string): string {
     const iconMap: Record<string, string> = {
-      'Sequence': '🔄',
-      'Flowchart': '📊',
-      'Assign': '📝',
-      'If': '🔀',
-      'While': '🔁',
-      'ForEach': '🔁',
-      'Click': '🖱️',
-      'TypeInto': '⌨️',
-      'GetText': '📄',
-      'LogMessage': '📋',
-      'InvokeWorkflowFile': '📤',
-      'TryCatch': '⚠️',
-      'Delay': '⏱️'
+      'Sequence': '[Seq]',
+      'Flowchart': '[Flow]',
+      'Assign': '[=]',
+      'If': '[?]',
+      'While': '[Loop]',
+      'ForEach': '[Loop]',
+      'Click': '[Click]',
+      'TypeInto': '[Type]',
+      'GetText': '[Get]',
+      'LogMessage': '[Log]',
+      'InvokeWorkflowFile': '[Invoke]',
+      'TryCatch': '[Try]',
+      'Delay': '[Wait]'
     };
 
-    return iconMap[type] || '📦';               // デフォルトアイコン
+    return iconMap[type] || '[Act]';            // デフォルトアイコン
   }
 }

--- a/packages/shared/renderer/tree-view-renderer.ts
+++ b/packages/shared/renderer/tree-view-renderer.ts
@@ -89,21 +89,21 @@ export class TreeViewRenderer {
    */
   private getActivityIcon(type: string): string {
     const iconMap: Record<string, string> = {
-      'Sequence': '🔄',
-      'Flowchart': '📊',
-      'Assign': '📝',
-      'If': '🔀',
-      'While': '🔁',
-      'ForEach': '🔁',
-      'Click': '🖱️',
-      'TypeInto': '⌨️',
-      'GetText': '📄',
-      'LogMessage': '📋',
-      'InvokeWorkflowFile': '📤',
-      'TryCatch': '⚠️',
-      'Delay': '⏱️'
+      'Sequence': '[Seq]',
+      'Flowchart': '[Flow]',
+      'Assign': '[=]',
+      'If': '[?]',
+      'While': '[Loop]',
+      'ForEach': '[Loop]',
+      'Click': '[Click]',
+      'TypeInto': '[Type]',
+      'GetText': '[Get]',
+      'LogMessage': '[Log]',
+      'InvokeWorkflowFile': '[Invoke]',
+      'TryCatch': '[Try]',
+      'Delay': '[Wait]'
     };
 
-    return iconMap[type] || '📦';               // デフォルトアイコン
+    return iconMap[type] || '[Act]';            // デフォルトアイコン
   }
 }


### PR DESCRIPTION
## Summary
- diff-renderer / tree-view-renderer のアクティビティアイコンを絵文字からテキストラベル (`[Seq]`, `[Flow]` 等) に変更
- diff バッジを `+`/`-`/`~` に変更
- スクリーンショットヘッダーから絵文字を除去

Closes #87

## Test plan
- [ ] GitHub 拡張機能でワークフロー表示時にテキストラベルが正しく表示されること
- [ ] PR diff ページでバッジが `+ 追加` / `- 削除` / `~ 変更` で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)