### PR TITLE
feat: Assignアクティビティの差分表示を改善

### DIFF
--- a/packages/shared/styles/diff.css
+++ b/packages/shared/styles/diff.css
@@ -193,6 +193,52 @@
   border-radius: 4px;
 }
 
+/* Assign代入式の表示 */
+.assign-expression {
+  font-family: 'Courier New', monospace;
+  padding: 4px 8px;
+  margin-top: 4px;
+  background-color: rgba(0, 0, 0, 0.03);        /* 薄い背景色 */
+  border-radius: 4px;
+  color: var(--color-fg-default, #333);
+}
+
+.diff-item.diff-added .assign-expression {
+  color: #28a745;                                /* 緑: 追加 */
+  background-color: rgba(40, 167, 69, 0.08);
+}
+
+.diff-item.diff-removed .assign-expression {
+  color: #d73a49;                                /* 赤: 削除 */
+  background-color: rgba(215, 58, 73, 0.08);
+}
+
+/* Assign変更詳細 */
+.assign-change-label {
+  font-weight: 600;
+  color: var(--color-fg-muted, #555);
+  margin-bottom: 2px;
+}
+
+.assign-change-side {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.assign-change-side.left {
+  background-color: #e3f2fd;                     /* 青系: 左辺 */
+  color: #1565c0;
+}
+
+.assign-change-side.right {
+  background-color: #f3e5f5;                     /* 紫系: 右辺 */
+  color: #7b1fa2;
+}
+
 /* セレクト */
 .select {
   padding: 8px 12px;

--- a/src/styles/diff.css
+++ b/src/styles/diff.css
@@ -193,6 +193,52 @@
   border-radius: 4px;
 }
 
+/* Assign代入式の表示 */
+.assign-expression {
+  font-family: 'Courier New', monospace;
+  padding: 4px 8px;
+  margin-top: 4px;
+  background-color: rgba(0, 0, 0, 0.03);        /* 薄い背景色 */
+  border-radius: 4px;
+  color: #333;
+}
+
+.diff-item.diff-added .assign-expression {
+  color: #28a745;                                /* 緑: 追加 */
+  background-color: rgba(40, 167, 69, 0.08);
+}
+
+.diff-item.diff-removed .assign-expression {
+  color: #d73a49;                                /* 赤: 削除 */
+  background-color: rgba(215, 58, 73, 0.08);
+}
+
+/* Assign変更詳細 */
+.assign-change-label {
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 2px;
+}
+
+.assign-change-side {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.assign-change-side.left {
+  background-color: #e3f2fd;                     /* 青系: 左辺 */
+  color: #1565c0;
+}
+
+.assign-change-side.right {
+  background-color: #f3e5f5;                     /* 紫系: 右辺 */
+  color: #7b1fa2;
+}
+
 /* セレクト */
 .select {
   padding: 8px 12px;


### PR DESCRIPTION
## 概要

Assignアクティビティの差分ビュー（diff view）表示を改善しました。

## 変更内容

### 追加/削除時の代入式表示
- Assignアクティビティが追加された場合、`+ 左辺 = 右辺` をGitHub風の緑色diff形式で表示
- 削除された場合は `- 左辺 = 右辺` を赤色diff形式で表示

### 変更時のAssign専用表示
- To/Valueの変更を「左辺」「右辺」ラベル付きで表示
- GitHub風に `-` 旧値（赤）/ `+` 新値（緑）の2行diff形式
- To/Value以外のプロパティ変更は従来通り表示

### HTMLエンティティデコード
- `&lt;`, `&gt;`, `&quot;`, `&amp;`, `&apos;`, `&nbsp;` を正しくデコードして表示

### 対象ファイル
- `packages/shared/renderer/diff-renderer.ts` - GitHub拡張機能用レンダラー
- `src/renderer/diff-renderer.ts` - Azure DevOps拡張機能用レンダラー
- `packages/shared/styles/diff.css` - GitHub拡張機能用スタイル
- `src/styles/diff.css` - Azure DevOps拡張機能用スタイル

Closes #89