### PR TITLE
feat: GitHub拡張パネルにデバッグ用Copy HTMLボタンを追加 (#91)

### DIFF
--- a/packages/github-extension/src/content.ts
+++ b/packages/github-extension/src/content.ts
@@ -562,8 +562,37 @@ function createPanel(): HTMLElement {
 	closeButton.className = 'btn btn-sm'; // ボタンスタイル
 	closeButton.addEventListener('click', () => panel.remove()); // クリックで閉じる
 
+	// Copy HTMLボタン（デバッグ用）
+	const copyHtmlButton = document.createElement('button'); // コピーボタン
+	copyHtmlButton.textContent = 'Copy HTML'; // ボタンテキスト
+	copyHtmlButton.className = 'btn btn-sm panel-copy-btn'; // スタイル適用
+	copyHtmlButton.addEventListener('click', () => { // クリックイベント
+		const originalText = copyHtmlButton.textContent; // 元のテキストを保存
+		navigator.clipboard.writeText(content.innerHTML) // コンテンツのHTMLをクリップボードにコピー
+			.then(() => {
+				copyHtmlButton.textContent = 'Copied!'; // 成功表示
+				copyHtmlButton.classList.add('panel-copy-btn-success'); // 成功スタイル
+			})
+			.catch(() => {
+				copyHtmlButton.textContent = 'Failed'; // 失敗表示
+				copyHtmlButton.classList.add('panel-copy-btn-error'); // 失敗スタイル
+			})
+			.finally(() => {
+				setTimeout(() => { // 1.5秒後に元に戻す
+					copyHtmlButton.textContent = originalText; // テキスト復元
+					copyHtmlButton.classList.remove('panel-copy-btn-success', 'panel-copy-btn-error'); // スタイル復元
+				}, 1500);
+			});
+	});
+
+	// ヘッダーボタングループ
+	const headerButtons = document.createElement('div'); // ボタンコンテナ
+	headerButtons.className = 'panel-header-buttons'; // スタイル適用
+	headerButtons.appendChild(copyHtmlButton); // コピーボタン追加
+	headerButtons.appendChild(closeButton); // 閉じるボタン追加
+
 	header.appendChild(titleArea);
-	header.appendChild(closeButton);
+	header.appendChild(headerButtons);
 
 	// コンテンツ部分
 	const content = document.createElement('div'); // コンテンツ

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -444,3 +444,35 @@
 #uipath-visualizer-panel .diff-content {
   max-width: 100%;
 }
+
+/* ========== ヘッダーボタングループ ========== */
+
+/* ボタンコンテナ */
+#uipath-visualizer-panel .panel-header-buttons {
+  display: flex;                            /* フレックスボックス */
+  align-items: center;                      /* 縦方向中央揃え */
+  gap: 8px;                                 /* ボタン間の間隔 */
+}
+
+/* Copy HTMLボタン（デバッグ用・控えめ表示） */
+#uipath-visualizer-panel .panel-copy-btn {
+  opacity: 0.7;                             /* 控えめな透明度 */
+  font-size: 12px;                          /* 小さめのフォント */
+  transition: opacity 0.2s;                 /* フェードアニメーション */
+}
+
+#uipath-visualizer-panel .panel-copy-btn:hover {
+  opacity: 1;                               /* ホバーで完全表示 */
+}
+
+/* コピー成功時のスタイル */
+#uipath-visualizer-panel .panel-copy-btn-success {
+  color: var(--diff-added-fg);              /* 緑色テキスト */
+  opacity: 1;                               /* 完全表示 */
+}
+
+/* コピー失敗時のスタイル */
+#uipath-visualizer-panel .panel-copy-btn-error {
+  color: var(--panel-error-fg);             /* 赤色テキスト */
+  opacity: 1;                               /* 完全表示 */
+}


### PR DESCRIPTION
## 概要

GitHub拡張機能のビジュアライザーパネルに、レンダラーが生成したHTMLをクリップボードにコピーできる「Copy HTML」ボタンを追加しました。

## 変更内容

- **`packages/github-extension/src/content.ts`**: `createPanel()` 関数にCopy HTMLボタンを追加
  - ヘッダー構造を `titleArea + closeButton` から `titleArea + headerButtons(copyHtmlButton + closeButton)` に変更
  - `navigator.clipboard.writeText(contentArea.innerHTML)` でHTMLをコピー
  - 成功時「Copied!」/ 失敗時「Failed」を1.5秒表示して元に戻すフィードバック

- **`packages/shared/styles/github-panel.css`**: ボタン用スタイルを追加
  - `.panel-header-buttons`: ボタングループ（flex, gap: 8px）
  - `.panel-copy-btn`: デバッグ用なので `opacity: 0.7` で控えめ表示、ホバーで `opacity: 1`
  - `.panel-copy-btn-success` / `.panel-copy-btn-error`: 成功/失敗時のフィードバックスタイル
  - 既存のCSSカスタムプロパティを使用するためダークモード対応は自動

Closes #91