### PR TITLE
feat: GitHub拡張機能でXAMLスクリーンショットを表示 (#96)

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -10,3 +10,5 @@ export { DiffRenderer } from './renderer/diff-renderer'; // 差分表示レン�
 // 型定義のエクスポート
 export type { Activity, ParsedXaml, Variable, Argument } from './parser/xaml-parser'; // 型定義
 export type { DiffResult, DiffActivity, DiffType, PropertyChange } from './parser/diff-calculator'; // 差分型定義
+export type { ScreenshotPathResolver, RendererOptions } from './renderer/sequence-renderer'; // スクリーンショットパス解決型
+export type { DiffRendererOptions } from './renderer/diff-renderer'; // 差分レンダラーオプション型

--- a/packages/shared/renderer/sequence-renderer.ts
+++ b/packages/shared/renderer/sequence-renderer.ts
@@ -1,9 +1,24 @@
 import { Activity } from '../parser/xaml-parser';
 
+/** スクリーンショットファイル名からURLパスを解決する関数型 */
+export type ScreenshotPathResolver = (filename: string) => string;
+
+/** SequenceRendererのオプション */
+export interface RendererOptions {
+  resolveScreenshotPath?: ScreenshotPathResolver; // スクリーンショットパス解決関数
+}
+
 /**
  * Sequenceワークフローのレンダラー
  */
 export class SequenceRenderer {
+  private screenshotPathResolver: ScreenshotPathResolver; // スクリーンショットパス解決関数
+
+  constructor(options?: RendererOptions) {
+    this.screenshotPathResolver = options?.resolveScreenshotPath // 注入された関数を使用
+      ?? ((filename) => `.screenshots/${filename}`);             // デフォルト: 相対パス
+  }
+
   /**
    * アクティビティツリーをHTMLとしてレンダリング
    */
@@ -172,9 +187,7 @@ export class SequenceRenderer {
    * スクリーンショットのパスを解決
    */
   private resolveScreenshotPath(filename: string): string {
-    // TODO: Azure DevOps APIを使用して実際のパスを取得
-    // 現時点ではプレースホルダーを返す
-    return `.screenshots/${filename}`;
+    return this.screenshotPathResolver(filename); // 注入された関数に委譲
   }
 
   /**

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -445,6 +445,174 @@
   max-width: 100%;
 }
 
+/* ========== スクリーンショット表示 ========== */
+
+/* スクリーンショットコンテナ */
+#uipath-visualizer-panel .informative-screenshot {
+  margin-top: 6px;
+  padding: 8px;
+  background-color: var(--screenshot-bg);       /* スクリーンショット背景色 */
+  border: 1px solid var(--screenshot-border);   /* スクリーンショットボーダー */
+  border-radius: 4px;
+}
+
+/* スクリーンショットラベル */
+#uipath-visualizer-panel .screenshot-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--panel-text-secondary);           /* セカンダリテキスト色 */
+  margin-bottom: 4px;
+}
+
+/* スクリーンショットサムネイル画像 */
+#uipath-visualizer-panel .screenshot-thumbnail {
+  max-width: 100%;
+  max-height: 200px;                            /* サムネイルの最大高さ */
+  object-fit: contain;                          /* アスペクト比を維持 */
+  border: 1px solid var(--panel-border-light);  /* 薄いボーダー */
+  border-radius: 4px;
+  cursor: pointer;                              /* クリック可能を示す */
+  display: block;
+}
+
+/* 拡大ボタン */
+#uipath-visualizer-panel .screenshot-expand-btn {
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  background: none;
+  border: 1px solid var(--panel-border);        /* ボーダー */
+  border-radius: 4px;
+  color: var(--panel-accent);                   /* アクセント色 */
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#uipath-visualizer-panel .screenshot-expand-btn:hover {
+  background-color: var(--panel-hover-bg);      /* ホバー背景 */
+}
+
+/* スクリーンショットエラー表示 */
+#uipath-visualizer-panel .screenshot-error {
+  font-size: 11px;
+  color: var(--panel-error-fg);                 /* エラーテキスト色 */
+  background-color: var(--panel-error-bg);      /* エラー背景色 */
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+/* スクリーンショットモーダル（拡大表示） */
+#uipath-visualizer-panel ~ .screenshot-modal,
+.screenshot-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);              /* 半透明黒背景 */
+  z-index: 10001;                               /* パネル（10000）より上 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.screenshot-modal .modal-content {
+  background: var(--panel-bg, #ffffff);          /* パネル背景色 */
+  border-radius: 8px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
+  cursor: default;
+}
+
+.screenshot-modal .modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--panel-border, #e0e0e0);
+}
+
+.screenshot-modal .modal-header h3 {
+  margin: 0;
+  font-size: 14px;
+  color: var(--panel-text-primary, #333);
+}
+
+.screenshot-modal .modal-close {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  color: var(--panel-text-secondary, #555);
+  padding: 4px 8px;
+}
+
+.screenshot-modal .modal-close:hover {
+  color: var(--panel-error-fg, #d13438);
+}
+
+.screenshot-modal .modal-body {
+  padding: 16px;
+}
+
+.screenshot-modal .modal-body img {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+}
+
+/* スクリーンショット差分比較表示 */
+#uipath-visualizer-panel .screenshot-compare {
+  margin-top: 8px;
+  padding: 8px;
+  background-color: var(--screenshot-bg);       /* スクリーンショット背景色 */
+  border: 1px solid var(--screenshot-border);   /* スクリーンショットボーダー */
+  border-radius: 4px;
+}
+
+#uipath-visualizer-panel .screenshot-compare .screenshot-header {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--panel-text-secondary);           /* セカンダリテキスト色 */
+  margin-bottom: 8px;
+}
+
+#uipath-visualizer-panel .compare-container {
+  display: flex;
+  gap: 12px;                                    /* Before/After間の間隔 */
+}
+
+#uipath-visualizer-panel .compare-container .screenshot-before,
+#uipath-visualizer-panel .compare-container .screenshot-after {
+  flex: 1;                                      /* 均等幅 */
+  text-align: center;
+}
+
+#uipath-visualizer-panel .compare-container .label {
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--panel-text-tertiary);            /* ターシャリテキスト色 */
+}
+
+#uipath-visualizer-panel .compare-container .screenshot-before .label {
+  color: var(--diff-removed-fg);                /* 赤: Before */
+}
+
+#uipath-visualizer-panel .compare-container .screenshot-after .label {
+  color: var(--diff-added-fg);                  /* 緑: After */
+}
+
+#uipath-visualizer-panel .compare-container img {
+  max-width: 100%;
+  max-height: 200px;
+  object-fit: contain;
+  border: 1px solid var(--panel-border-light);  /* 薄いボーダー */
+  border-radius: 4px;
+}
+
 /* ========== ヘッダーボタングループ ========== */
 
 /* ボタンコンテナ */


### PR DESCRIPTION
## Summary
- `SequenceRenderer`/`DiffRenderer`にスクリーンショットパス解決関数（`ScreenshotPathResolver`）を注入可能にした
- GitHub拡張機能でRawボタンのhrefやPR情報からGitHub raw URLを構築し、`.screenshots/`内の画像を正しく表示
- スクリーンショット表示用のCSSルール（サムネイル、モーダル、差分比較、エラー表示）を追加

## Test plan
- [ ] `npm run build:shared && npm run build` でビルド成功を確認
- [ ] GitHub上の公開リポジトリでblob表示時にスクリーンショットが表示されることを確認
- [ ] PR差分ページでスクリーンショット変更のBefore/After比較が表示されることを確認
- [ ] ダークモードでスクリーンショット表示のスタイルが正しく適用されることを確認
- [ ] Azure DevOps拡張（引数なし）が従来通り動作することを確認

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)