### PR TITLE
feat: sap:プレフィックスのプロパティを差分表示から除外

### DIFF
--- a/packages/shared/parser/diff-calculator.ts
+++ b/packages/shared/parser/diff-calculator.ts
@@ -40,6 +40,11 @@ export interface DiffResult {
 /**
  * 差分計算クラス
  */
+/** 差分表示から除外するプロパティのプレフィックス */
+const IGNORED_PROPERTY_PREFIXES = [
+  'sap:',          // UIレイアウトメタデータ（HintSize等）
+];
+
 export class DiffCalculator {
   /**
    * 2つのアクティビティツリーの差分を計算
@@ -145,8 +150,9 @@ export class DiffCalculator {
       ...Object.keys(after.properties)
     ]);
 
-    // 各プロパティを比較
+    // 各プロパティを比較（除外プレフィックスに該当するものはスキップ）
     allPropertyNames.forEach(propName => {
+      if (IGNORED_PROPERTY_PREFIXES.some(prefix => propName.startsWith(prefix))) return;
       const beforeValue = before.properties[propName];
       const afterValue = after.properties[propName];
 

--- a/src/parser/diff-calculator.ts
+++ b/src/parser/diff-calculator.ts
@@ -40,6 +40,11 @@ export interface DiffResult {
 /**
  * 差分計算クラス
  */
+/** 差分表示から除外するプロパティのプレフィックス */
+const IGNORED_PROPERTY_PREFIXES = [
+  'sap:',          // UIレイアウトメタデータ（HintSize等）
+];
+
 export class DiffCalculator {
   /**
    * 2つのアクティビティツリーの差分を計算
@@ -144,8 +149,9 @@ export class DiffCalculator {
       ...Object.keys(after.properties)
     ]);
 
-    // 各プロパティを比較
+    // 各プロパティを比較（除外プレフィックスに該当するものはスキップ）
     allPropertyNames.forEach(propName => {
+      if (IGNORED_PROPERTY_PREFIXES.some(prefix => propName.startsWith(prefix))) return;
       const beforeValue = before.properties[propName];
       const afterValue = after.properties[propName];
 


### PR DESCRIPTION
## 概要

差分表示で `sap:VirtualizedContainerService.HintSize` など、UiPath Studio が自動生成するUIレイアウト属性がノイズとして表示される問題を修正。

## 変更内容

- `sap:` プレフィックスで始まるプロパティをすべて差分比較から除外
- プレフィックスベースの除外により、今後 `sap:` 系の属性が増えても自動的に対応

## 変更ファイル

- `packages/shared/parser/diff-calculator.ts`
- `src/parser/diff-calculator.ts`

Closes #103