### PR TITLE
feat: アクティビティに行番号範囲バッジを表示してレビューコメント連携を追加

### DIFF
--- a/packages/github-extension/src/review-comments.ts
+++ b/packages/github-extension/src/review-comments.ts
@@ -1,0 +1,271 @@
+/**
+ * GitHub PR レビューコメント取得・投稿・マッピングモジュール
+ * コメントの取得、アクティビティへのマッピング、新規コメント投稿を担当
+ */
+
+import type { ActivityLineIndex } from '@uipath-xaml-visualizer/shared'; // 行マッピング型定義
+
+// ========== 型定義 ==========
+
+/**
+ * PRの基本情報
+ */
+export interface PrInfo {
+  owner: string;   // リポジトリオーナー
+  repo: string;    // リポジトリ名
+  prNumber: number; // PR番号
+}
+
+/**
+ * GitHub PRレビューコメント
+ */
+export interface ReviewComment {
+  id: number;                // コメントID
+  body: string;              // コメント本文
+  user: {                    // 投稿ユーザー
+    login: string;           // ユーザー名
+    avatar_url: string;      // アバターURL
+  };
+  created_at: string;        // 作成日時
+  updated_at: string;        // 更新日時
+  path: string;              // ファイルパス
+  line: number | null;       // コメント対象行（endLine）
+  start_line: number | null; // 複数行コメントの開始行
+  side: 'LEFT' | 'RIGHT';   // diff側（LEFT=base, RIGHT=head）
+  html_url: string;          // コメントのWeb URL
+}
+
+/**
+ * コメント投稿パラメータ
+ */
+export interface PostCommentParams {
+  body: string;       // コメント本文
+  commitId: string;   // コミットSHA
+  path: string;       // ファイルパス
+  line: number;       // コメント対象行（endLine）
+  startLine?: number; // 複数行コメントの開始行
+  side: 'LEFT' | 'RIGHT'; // diff側
+}
+
+// ========== コメント取得 ==========
+
+/**
+ * PR のレビューコメントを取得（ファイルパスでフィルタ）
+ */
+export async function fetchReviewComments(
+  pr: PrInfo,
+  filePath: string
+): Promise<ReviewComment[]> {
+  const allComments: ReviewComment[] = []; // 全コメント
+  let page = 1; // ページ番号
+  const perPage = 100; // 1ページあたりの取得数
+
+  // ページネーション対応でコメントを全件取得
+  while (true) {
+    const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.prNumber}/comments?per_page=${perPage}&page=${page}`; // API URL
+
+    let response: Response | null = null; // レスポンス
+
+    // 方法1: credentials: 'include'（Chrome拡張のhost_permissionsでCookie送信）
+    try {
+      response = await fetch(url, {
+        credentials: 'include', // Cookie付きリクエスト
+        headers: { 'Accept': 'application/vnd.github.v3+json' } // GitHub API v3
+      });
+    } catch (e) {
+      console.warn('UiPath Visualizer: コメント取得エラー (include):', e);
+    }
+
+    // 方法2: credentials: 'same-origin' にフォールバック
+    if (!response || !response.ok) {
+      try {
+        response = await fetch(url, {
+          credentials: 'same-origin', // 同一オリジンCookie送信
+          headers: { 'Accept': 'application/vnd.github.v3+json' }
+        });
+      } catch (e) {
+        console.warn('UiPath Visualizer: コメント取得エラー (same-origin):', e);
+      }
+    }
+
+    // 方法3: Cookie なしフォールバック（パブリックリポジトリ用）
+    if (!response || !response.ok) {
+      try {
+        response = await fetch(url, {
+          headers: { 'Accept': 'application/vnd.github.v3+json' }
+        });
+      } catch (e) {
+        console.warn('UiPath Visualizer: コメント取得エラー (no-auth):', e);
+        break; // 全手段失敗
+      }
+    }
+
+    if (!response || !response.ok) {
+      console.warn(`UiPath Visualizer: コメント取得失敗: status=${response?.status}`);
+      break;
+    }
+
+    const data: ReviewComment[] = await response.json(); // レスポンスをパース
+
+    if (data.length === 0) break; // これ以上コメントなし
+
+    // ファイルパスでフィルタして追加
+    const filtered = data.filter(comment => comment.path === filePath); // 対象ファイルのコメントのみ
+    allComments.push(...filtered);
+
+    if (data.length < perPage) break; // 最後のページ
+    page++; // 次のページ
+  }
+
+  console.log(`UiPath Visualizer: レビューコメント ${allComments.length}件取得 (${filePath})`);
+  return allComments;
+}
+
+// ========== コメント → アクティビティマッピング ==========
+
+/**
+ * レビューコメントをアクティビティキーにマッピング
+ */
+export function mapCommentsToActivities(
+  comments: ReviewComment[],
+  headLineIndex: ActivityLineIndex | null,
+  baseLineIndex: ActivityLineIndex | null
+): Map<string, ReviewComment[]> {
+  const commentsMap = new Map<string, ReviewComment[]>(); // 結果マップ
+
+  for (const comment of comments) {
+    const targetLine = comment.line; // コメント対象行
+    if (!targetLine) continue; // 行番号なしのコメントはスキップ
+
+    // side に基づいて適切な行マップを選択
+    const lineIndex = comment.side === 'LEFT' ? baseLineIndex : headLineIndex; // LEFT=base, RIGHT=head
+    if (!lineIndex) continue; // 行マップがない場合はスキップ
+
+    const activityKey = lineIndex.lineToKey.get(targetLine); // 行番号からアクティビティキーを逆引き
+    if (!activityKey) continue; // マッピングできないコメントはスキップ
+
+    // マップに追加
+    const existing = commentsMap.get(activityKey) || []; // 既存コメントリスト
+    existing.push(comment);
+    commentsMap.set(activityKey, existing);
+  }
+
+  console.log(`UiPath Visualizer: ${commentsMap.size}個のアクティビティにコメントをマッピング`);
+  return commentsMap;
+}
+
+// ========== コメント投稿 ==========
+
+/**
+ * レビューコメントを投稿
+ */
+export async function postReviewComment(
+  pr: PrInfo,
+  params: PostCommentParams
+): Promise<ReviewComment | null> {
+  const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.prNumber}/comments`; // API URL
+
+  // リクエストボディ
+  const body: Record<string, any> = {
+    body: params.body,               // コメント本文
+    commit_id: params.commitId,      // コミットSHA
+    path: params.path,               // ファイルパス
+    line: params.line,               // コメント対象行
+    side: params.side                // diff側
+  };
+
+  // 複数行コメントの場合はstart_lineを追加
+  if (params.startLine && params.startLine !== params.line) {
+    body.start_line = params.startLine; // 開始行
+    body.start_side = params.side; // 開始行のdiff側
+  }
+
+  // 方法1: credentials: 'include' でAPI経由投稿
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      credentials: 'include', // Cookie付きリクエスト
+      headers: {
+        'Accept': 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body) // ボディをJSON文字列化
+    });
+
+    if (response.ok) {
+      const comment: ReviewComment = await response.json(); // レスポンスをパース
+      console.log('UiPath Visualizer: コメント投稿成功 (API)');
+      return comment;
+    }
+
+    console.warn(`UiPath Visualizer: コメント投稿失敗 (API): status=${response.status}`);
+  } catch (e) {
+    console.warn('UiPath Visualizer: コメント投稿エラー (API):', e);
+  }
+
+  // 方法2: GitHub DOM内のCSRFトークンを使った同一オリジンPOSTにフォールバック
+  try {
+    const csrfToken = extractCsrfToken(); // CSRFトークンを取得
+    if (csrfToken) {
+      const formUrl = `https://github.com/${pr.owner}/${pr.repo}/pull/${pr.prNumber}/review_comment`; // GitHub内部エンドポイント
+
+      const formData = new FormData(); // フォームデータ
+      formData.append('authenticity_token', csrfToken); // CSRFトークン
+      formData.append('comment[body]', params.body); // コメント本文
+      formData.append('comment[commit_id]', params.commitId); // コミットSHA
+      formData.append('comment[path]', params.path); // ファイルパス
+      formData.append('comment[line]', String(params.line)); // 対象行
+      formData.append('comment[side]', params.side); // diff側
+
+      if (params.startLine && params.startLine !== params.line) {
+        formData.append('comment[start_line]', String(params.startLine)); // 開始行
+        formData.append('comment[start_side]', params.side); // 開始行のdiff側
+      }
+
+      const response = await fetch(formUrl, {
+        method: 'POST',
+        credentials: 'same-origin', // 同一オリジンCookie送信
+        body: formData
+      });
+
+      if (response.ok) {
+        console.log('UiPath Visualizer: コメント投稿成功 (CSRF fallback)');
+        // フォールバックではレスポンスがHTMLのため、最低限の情報で返す
+        return {
+          id: Date.now(), // 仮ID
+          body: params.body,
+          user: { login: '', avatar_url: '' },
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          path: params.path,
+          line: params.line,
+          start_line: params.startLine || null,
+          side: params.side,
+          html_url: ''
+        };
+      }
+    }
+  } catch (e) {
+    console.warn('UiPath Visualizer: コメント投稿エラー (CSRF fallback):', e);
+  }
+
+  console.error('UiPath Visualizer: コメント投稿失敗 - 全手段で失敗');
+  return null;
+}
+
+// ========== ヘルパー関数 ==========
+
+/**
+ * GitHub ページからCSRFトークンを抽出
+ */
+function extractCsrfToken(): string | null {
+  // meta タグから取得
+  const metaTag = document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement; // CSRFメタタグ
+  if (metaTag?.content) return metaTag.content;
+
+  // hidden input から取得
+  const input = document.querySelector('input[name="authenticity_token"]') as HTMLInputElement; // CSRFトークンinput
+  if (input?.value) return input.value;
+
+  return null;
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,6 +1,7 @@
 // XAMLパーサーのエクスポート
 export { XamlParser } from './parser/xaml-parser'; // XAML解析クラス
-export { DiffCalculator } from './parser/diff-calculator'; // 差分計算クラス
+export { DiffCalculator, buildActivityKey } from './parser/diff-calculator'; // 差分計算クラス・キー生成関数
+export { XamlLineMapper } from './parser/line-mapper'; // XAML行番号マッパー
 
 // レンダラーのエクスポート
 export { SequenceRenderer } from './renderer/sequence-renderer'; // Sequenceレンダリングクラス
@@ -10,3 +11,5 @@ export { DiffRenderer } from './renderer/diff-renderer'; // 差分表示レン�
 // 型定義のエクスポート
 export type { Activity, ParsedXaml, Variable, Argument } from './parser/xaml-parser'; // 型定義
 export type { DiffResult, DiffActivity, DiffType, PropertyChange } from './parser/diff-calculator'; // 差分型定義
+export type { ActivityLineRange, ActivityLineIndex } from './parser/line-mapper'; // 行マッピング型定義
+export type { CommentRenderOptions, ReviewCommentData } from './renderer/diff-renderer'; // コメントUI型定義

--- a/packages/shared/parser/diff-calculator.ts
+++ b/packages/shared/parser/diff-calculator.ts
@@ -1,6 +1,15 @@
 import { Activity } from './xaml-parser';
 
 /**
+ * アクティビティの一意キーを生成（差分計算・行マッピング共通）
+ * IdRef（安定した一意識別子）を優先使用、なければフォールバック
+ */
+export function buildActivityKey(activity: Activity, index: number): string {
+  const idRef = activity.properties['sap2010:WorkflowViewState.IdRef']; // IdRef属性
+  return idRef || `${activity.type}_${activity.displayName}_${index}`; // フォールバック
+}
+
+/**
  * 差分の種類
  */
 export enum DiffType {
@@ -126,9 +135,7 @@ export class DiffCalculator {
     const map = new Map<string, Activity>();
 
     activities.forEach((activity, index) => {
-      // IdRef（安定した一意識別子）を優先使用、なければフォールバック
-      const idRef = activity.properties['sap2010:WorkflowViewState.IdRef'];
-      const key = idRef || `${activity.type}_${activity.displayName}_${index}`;
+      const key = buildActivityKey(activity, index); // 共有キー生成関数を使用
       map.set(key, activity);
     });
 

--- a/packages/shared/parser/line-mapper.ts
+++ b/packages/shared/parser/line-mapper.ts
@@ -1,0 +1,208 @@
+/**
+ * XAML行番号マッパー
+ * XAMLテキストを行単位でスキャンし、各アクティビティの開始行・終了行を特定する
+ */
+
+
+/**
+ * アクティビティの行範囲
+ */
+export interface ActivityLineRange {
+  activityKey: string;   // アクティビティの一意キー
+  displayName: string;   // 表示名
+  type: string;          // アクティビティタイプ
+  startLine: number;     // 開始行（1-based）
+  endLine: number;       // 終了行（1-based）
+}
+
+/**
+ * 双方向インデックス
+ */
+export interface ActivityLineIndex {
+  keyToLines: Map<string, ActivityLineRange>;  // アクティビティキー → 行範囲
+  lineToKey: Map<number, string>;              // 行番号 → アクティビティキー
+}
+
+/**
+ * XMLタグ情報
+ */
+interface TagInfo {
+  line: number;         // タグが出現する行番号（1-based）
+  tagName: string;      // タグ名（名前空間プレフィックス除去済み）
+  fullTagName: string;  // 完全なタグ名（プレフィックス付き）
+  isClose: boolean;     // 閉じタグかどうか
+  isSelfClose: boolean; // 自己閉じタグかどうか
+  attributes: Map<string, string>; // 属性名→値のマップ
+}
+
+/**
+ * XAML行番号マッパークラス
+ */
+export class XamlLineMapper {
+  /**
+   * XAMLテキストから行番号インデックスを構築
+   */
+  static buildLineMap(xamlText: string): ActivityLineIndex {
+    const keyToLines = new Map<string, ActivityLineRange>(); // キー→行範囲マップ
+    const lineToKey = new Map<number, string>(); // 行→キーマップ
+
+    if (!xamlText) {
+      return { keyToLines, lineToKey }; // 空テキストの場合は空マップを返す
+    }
+
+    const lines = xamlText.split('\n'); // 行に分割
+    const tagStack: { tagName: string; startLine: number; attributes: Map<string, string> }[] = []; // タグスタック
+    const activityCounters = new Map<string, number>(); // アクティビティタイプごとの出現回数
+
+    for (let i = 0; i < lines.length; i++) {
+      const lineNum = i + 1; // 1-based行番号
+      const line = lines[i]; // 現在の行
+
+      const tags = XamlLineMapper.extractTags(line, lineNum); // 行内のタグを抽出
+
+      for (const tag of tags) {
+        if (tag.isSelfClose) {
+          // 自己閉じタグ: 1行で完結するアクティビティ
+          XamlLineMapper.registerActivity(
+            tag, lineNum, lineNum,
+            activityCounters, keyToLines, lineToKey
+          );
+        } else if (tag.isClose) {
+          // 閉じタグ: スタックから対応する開始タグを検索
+          for (let j = tagStack.length - 1; j >= 0; j--) {
+            if (tagStack[j].tagName === tag.tagName) {
+              const openTag = tagStack.splice(j, 1)[0]; // スタックから取り出し
+              XamlLineMapper.registerActivityFromStack(
+                openTag, lineNum,
+                activityCounters, keyToLines, lineToKey
+              );
+              break;
+            }
+          }
+        } else {
+          // 開始タグ: スタックにプッシュ
+          tagStack.push({
+            tagName: tag.tagName,
+            startLine: lineNum,
+            attributes: tag.attributes
+          });
+        }
+      }
+    }
+
+    return { keyToLines, lineToKey }; // 構築したインデックスを返す
+  }
+
+  /**
+   * 行からXMLタグを抽出
+   */
+  private static extractTags(line: string, lineNum: number): TagInfo[] {
+    const tags: TagInfo[] = []; // 抽出結果
+
+    // XMLタグを検出する正規表現（開始タグ、閉じタグ、自己閉じタグ）
+    const tagPattern = /<(\/?)([a-zA-Z0-9_:.]+)((?:\s+[^>]*?)?)(\/?)\s*>/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = tagPattern.exec(line)) !== null) {
+      const isClose = match[1] === '/'; // 閉じタグかどうか
+      const fullTagName = match[2]; // 完全なタグ名
+      const attrStr = match[3]; // 属性文字列
+      const isSelfClose = match[4] === '/'; // 自己閉じタグかどうか
+
+      // 名前空間プレフィックスを除去したタグ名
+      const tagName = fullTagName.includes(':')
+        ? fullTagName.split(':').pop()! // コロン以降を取得
+        : fullTagName;
+
+      // 属性を解析
+      const attributes = new Map<string, string>();
+      if (attrStr) {
+        const attrPattern = /([a-zA-Z0-9_:.]+)\s*=\s*"([^"]*)"/g; // 属性パターン
+        let attrMatch: RegExpExecArray | null;
+        while ((attrMatch = attrPattern.exec(attrStr)) !== null) {
+          attributes.set(attrMatch[1], attrMatch[2]); // 属性を記録
+        }
+      }
+
+      tags.push({
+        line: lineNum,
+        tagName,
+        fullTagName,
+        isClose,
+        isSelfClose,
+        attributes
+      });
+    }
+
+    return tags;
+  }
+
+  /**
+   * 自己閉じタグのアクティビティを登録
+   */
+  private static registerActivity(
+    tag: TagInfo,
+    startLine: number,
+    endLine: number,
+    counters: Map<string, number>,
+    keyToLines: Map<string, ActivityLineRange>,
+    lineToKey: Map<number, string>
+  ): void {
+    const idRef = tag.attributes.get('sap2010:WorkflowViewState.IdRef'); // IdRef属性
+    const displayName = tag.attributes.get('DisplayName') || tag.tagName; // 表示名
+    const type = tag.tagName; // アクティビティタイプ
+
+    // インデックスをカウント（buildActivityKeyと同じフォールバックロジック）
+    const counterKey = `${type}_${displayName}`; // カウンターキー
+    const index = counters.get(counterKey) || 0; // 現在のインデックス
+    counters.set(counterKey, index + 1); // インクリメント
+
+    // アクティビティキーを生成（buildActivityKeyと同じロジック）
+    const activityKey = idRef || `${type}_${displayName}_${index}`;
+
+    const range: ActivityLineRange = { activityKey, displayName, type, startLine, endLine };
+    keyToLines.set(activityKey, range); // キー→行範囲を登録
+
+    // 行番号→キーのマッピングを登録
+    for (let line = startLine; line <= endLine; line++) {
+      lineToKey.set(line, activityKey); // 各行にキーを割り当て
+    }
+  }
+
+  /**
+   * スタックから取り出した開始タグ情報でアクティビティを登録
+   */
+  private static registerActivityFromStack(
+    openTag: { tagName: string; startLine: number; attributes: Map<string, string> },
+    endLine: number,
+    counters: Map<string, number>,
+    keyToLines: Map<string, ActivityLineRange>,
+    lineToKey: Map<number, string>
+  ): void {
+    const idRef = openTag.attributes.get('sap2010:WorkflowViewState.IdRef'); // IdRef属性
+    const displayName = openTag.attributes.get('DisplayName') || openTag.tagName; // 表示名
+    const type = openTag.tagName; // アクティビティタイプ
+
+    // インデックスをカウント
+    const counterKey = `${type}_${displayName}`; // カウンターキー
+    const index = counters.get(counterKey) || 0; // 現在のインデックス
+    counters.set(counterKey, index + 1); // インクリメント
+
+    // アクティビティキーを生成
+    const activityKey = idRef || `${type}_${displayName}_${index}`;
+
+    const range: ActivityLineRange = {
+      activityKey,
+      displayName,
+      type,
+      startLine: openTag.startLine,
+      endLine
+    };
+    keyToLines.set(activityKey, range); // キー→行範囲を登録
+
+    // 行番号→キーのマッピングを登録
+    for (let line = openTag.startLine; line <= endLine; line++) {
+      lineToKey.set(line, activityKey); // 各行にキーを割り当て
+    }
+  }
+}

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -390,6 +390,35 @@
   }
 }
 
+/* ========== 行番号バッジ ========== */
+
+/* 行範囲バッジ（ヘッダー右端に配置） */
+#uipath-visualizer-panel .line-range-badge {
+  display: inline-block;                      /* インラインブロック */
+  margin-left: auto;                          /* 右端に寄せる */
+  padding: 1px 6px;                           /* パディング */
+  font-size: 11px;                            /* 小さめフォント */
+  font-family: 'Courier New', monospace;      /* 等幅フォント */
+  font-weight: 400;                           /* 通常ウェイト */
+  color: var(--panel-text-muted);             /* 控えめテキスト色 */
+  background-color: var(--panel-bg-secondary); /* セカンダリ背景 */
+  border: 1px solid var(--panel-border-light); /* ボーダー */
+  border-radius: 4px;                         /* 角丸 */
+  white-space: nowrap;                        /* 折り返さない */
+  flex-shrink: 0;                             /* 縮小しない */
+  cursor: default;                            /* デフォルトカーソル */
+}
+
+#uipath-visualizer-panel .line-range-badge:hover {
+  color: var(--panel-accent);                 /* ホバーでアクセント色 */
+  border-color: var(--panel-accent);          /* ホバーボーダー */
+}
+
+/* ツリービュー内の行番号バッジ */
+#uipath-visualizer-panel .tree-item .line-range-badge {
+  margin-left: 8px;                           /* ラベルとの間隔 */
+}
+
 /* ========== プロパティ変更 ========== */
 
 #uipath-visualizer-panel .property-changes {
@@ -475,4 +504,180 @@
 #uipath-visualizer-panel .panel-copy-btn-error {
   color: var(--panel-error-fg);             /* 赤色テキスト */
   opacity: 1;                               /* 完全表示 */
+}
+
+/* ========== レビューコメント UI ========== */
+
+/* コメントインジケーターバッジ */
+#uipath-visualizer-panel .comment-indicator {
+  font-size: 11px;                          /* 小さめフォント */
+  color: var(--panel-accent);               /* アクセント色 */
+  font-weight: 600;                         /* 太字 */
+  margin-left: 8px;                         /* 左マージン */
+  padding: 1px 4px;                         /* パディング */
+  border-radius: 4px;                       /* 角丸 */
+  background-color: var(--panel-bg-secondary); /* 背景色 */
+  border: 1px solid var(--panel-border-light); /* ボーダー */
+  white-space: nowrap;                      /* 折り返さない */
+}
+
+#uipath-visualizer-panel .comment-indicator:hover {
+  background-color: var(--panel-hover-bg);  /* ホバー背景 */
+  border-color: var(--panel-accent);        /* ホバーボーダー */
+}
+
+/* コメント追加ボタン（ホバー時のみ表示） */
+#uipath-visualizer-panel .add-comment-btn {
+  font-size: 11px;                          /* 小さめフォント */
+  color: var(--panel-text-muted);           /* 控えめテキスト色 */
+  cursor: pointer;                          /* クリック可能 */
+  margin-left: 4px;                         /* 左マージン */
+  padding: 1px 4px;                         /* パディング */
+  border-radius: 4px;                       /* 角丸 */
+  opacity: 0;                               /* 通常時は非表示 */
+  transition: opacity 0.2s;                 /* フェードアニメーション */
+}
+
+#uipath-visualizer-panel .activity-card:hover .add-comment-btn {
+  opacity: 1;                               /* ホバー時に表示 */
+}
+
+#uipath-visualizer-panel .add-comment-btn:hover {
+  color: var(--panel-accent);               /* ホバーでアクセント色 */
+  background-color: var(--panel-hover-bg);  /* ホバー背景 */
+}
+
+/* コメントパネルコンテナ */
+#uipath-visualizer-panel .activity-comments {
+  margin-top: 8px;                          /* 上マージン */
+  padding: 8px;                             /* パディング */
+  background-color: var(--panel-bg-secondary); /* 背景色 */
+  border: 1px solid var(--panel-border-light); /* ボーダー */
+  border-radius: 6px;                       /* 角丸 */
+}
+
+/* コメントリスト */
+#uipath-visualizer-panel .comment-list {
+  display: flex;                            /* フレックスボックス */
+  flex-direction: column;                   /* 縦方向 */
+  gap: 8px;                                 /* コメント間の間隔 */
+}
+
+/* 個別コメント */
+#uipath-visualizer-panel .comment-item {
+  padding: 8px;                             /* パディング */
+  background-color: var(--panel-bg);        /* 背景色 */
+  border: 1px solid var(--panel-border-light); /* ボーダー */
+  border-radius: 4px;                       /* 角丸 */
+}
+
+/* コメントヘッダー（アバター + ユーザー名 + タイムスタンプ） */
+#uipath-visualizer-panel .comment-header {
+  display: flex;                            /* フレックスボックス */
+  align-items: center;                      /* 縦方向中央 */
+  gap: 6px;                                 /* 要素間の間隔 */
+  margin-bottom: 4px;                       /* 下マージン */
+}
+
+/* アバター画像 */
+#uipath-visualizer-panel .comment-avatar {
+  width: 20px;                              /* 幅 */
+  height: 20px;                             /* 高さ */
+  border-radius: 50%;                       /* 円形 */
+}
+
+/* ユーザー名 */
+#uipath-visualizer-panel .comment-username {
+  font-weight: 600;                         /* 太字 */
+  font-size: 12px;                          /* フォントサイズ */
+  color: var(--panel-text-primary);         /* テキスト色 */
+}
+
+/* タイムスタンプ */
+#uipath-visualizer-panel .comment-timestamp {
+  font-size: 11px;                          /* 小さめフォント */
+  color: var(--panel-text-muted);           /* グレー色 */
+}
+
+/* コメント本文 */
+#uipath-visualizer-panel .comment-body {
+  font-size: 13px;                          /* フォントサイズ */
+  line-height: 1.5;                         /* 行高 */
+  color: var(--panel-text-secondary);       /* テキスト色 */
+  white-space: pre-wrap;                    /* 折り返し・改行保持 */
+  word-break: break-word;                   /* 長い単語を折り返す */
+}
+
+/* コメント入力フォーム */
+#uipath-visualizer-panel .comment-form {
+  margin-top: 8px;                          /* 上マージン */
+  padding: 8px;                             /* パディング */
+  background-color: var(--panel-bg-secondary); /* 背景色 */
+  border: 1px solid var(--panel-border-light); /* ボーダー */
+  border-radius: 6px;                       /* 角丸 */
+}
+
+/* テキストエリア */
+#uipath-visualizer-panel .comment-input {
+  width: 100%;                              /* 全幅 */
+  min-height: 60px;                         /* 最小高さ */
+  padding: 8px;                             /* パディング */
+  border: 1px solid var(--panel-border);    /* ボーダー */
+  border-radius: 4px;                       /* 角丸 */
+  background-color: var(--panel-bg);        /* 背景色 */
+  color: var(--panel-text-primary);         /* テキスト色 */
+  font-size: 13px;                          /* フォントサイズ */
+  font-family: inherit;                     /* フォント継承 */
+  resize: vertical;                         /* 縦方向のみリサイズ可能 */
+  box-sizing: border-box;                   /* ボーダーをサイズに含む */
+}
+
+#uipath-visualizer-panel .comment-input:focus {
+  outline: none;                            /* デフォルトアウトライン除去 */
+  border-color: var(--panel-accent);        /* フォーカス時のボーダー色 */
+  box-shadow: 0 0 0 2px rgba(0, 120, 212, 0.2); /* フォーカスシャドウ */
+}
+
+/* ボタン群 */
+#uipath-visualizer-panel .comment-form-actions {
+  display: flex;                            /* フレックスボックス */
+  justify-content: flex-end;                /* 右寄せ */
+  gap: 8px;                                 /* ボタン間の間隔 */
+  margin-top: 8px;                          /* 上マージン */
+}
+
+/* キャンセルボタン */
+#uipath-visualizer-panel .comment-cancel-btn {
+  color: var(--panel-text-tertiary);        /* テキスト色 */
+  background-color: var(--panel-bg);        /* 背景色 */
+  border: 1px solid var(--panel-border);    /* ボーダー */
+  padding: 4px 12px;                        /* パディング */
+  border-radius: 4px;                       /* 角丸 */
+  cursor: pointer;                          /* クリック可能 */
+  font-size: 12px;                          /* フォントサイズ */
+}
+
+#uipath-visualizer-panel .comment-cancel-btn:hover {
+  background-color: var(--panel-hover-bg);  /* ホバー背景 */
+}
+
+/* 投稿ボタン */
+#uipath-visualizer-panel .comment-submit-btn {
+  color: white;                             /* テキスト色 */
+  background-color: var(--panel-accent);    /* 背景色 */
+  border: 1px solid var(--panel-accent);    /* ボーダー */
+  padding: 4px 12px;                        /* パディング */
+  border-radius: 4px;                       /* 角丸 */
+  cursor: pointer;                          /* クリック可能 */
+  font-size: 12px;                          /* フォントサイズ */
+  font-weight: 600;                         /* 太字 */
+}
+
+#uipath-visualizer-panel .comment-submit-btn:hover {
+  background-color: var(--panel-accent-hover); /* ホバー背景 */
+}
+
+#uipath-visualizer-panel .comment-submit-btn:disabled {
+  opacity: 0.6;                             /* 無効時の透明度 */
+  cursor: not-allowed;                      /* 無効カーソル */
 }


### PR DESCRIPTION
## 概要

View XAML 画面で、各アクティビティカードに対応するXAMLの行番号範囲（例: `L3-L45`）をバッジとして表示する。
GitHubのレビューコメント（行番号ベース）とアクティビティの対応を一目で把握できるようにする。

## 変更内容

- `XamlLineMapper` で各アクティビティのXAML行範囲（startLine/endLine）を計算
- `DiffRenderer` / `SequenceRenderer` / `TreeViewRenderer` に行番号バッジ（`L10-L15`）を表示
- レビューコメントの取得・投稿・アクティビティへのマッピング機能を追加
- コメントUI（インジケーター・入力フォーム・パネル）を `DiffRenderer` に実装

## 表示イメージ

```
┌──────────────────────────────────────────┐
│ [Seq] Main Sequence  [+ 追加]   L3-L45   │
│ ┌──────────────────────────────────────┐ │
│ │ [=] Set Variable  [~ 変更]   L10-L15 │ │
│ └──────────────────────────────────────┘ │
└──────────────────────────────────────────┘
```

Closes #105