### PR TITLE
feat: ViewState関連プロパティを差分表示から除外

### DIFF
--- a/packages/shared/parser/diff-calculator.ts
+++ b/packages/shared/parser/diff-calculator.ts
@@ -52,6 +52,7 @@ export interface DiffResult {
 /** 差分表示から除外するプロパティのプレフィックス */
 const IGNORED_PROPERTY_PREFIXES = [
   'sap:',          // UIレイアウトメタデータ（HintSize等）
+  'sap2010:',      // ViewState関連メタデータ（WorkflowViewState.IdRef等）
 ];
 
 export class DiffCalculator {

--- a/packages/shared/parser/xaml-parser.ts
+++ b/packages/shared/parser/xaml-parser.ts
@@ -313,6 +313,7 @@ export class XamlParser {
 
         // プロパティ要素（タイプ名.プロパティ名形式）
         if (childName && childName.includes('.')) {
+          if (this.isMetadataElement(childElem)) continue; // メタデータ要素は除外
           const [, propName] = childName.split('.');
           properties[propName] = this.extractPropertyValue(childElem);
         }

--- a/src/parser/diff-calculator.ts
+++ b/src/parser/diff-calculator.ts
@@ -43,6 +43,7 @@ export interface DiffResult {
 /** 差分表示から除外するプロパティのプレフィックス */
 const IGNORED_PROPERTY_PREFIXES = [
   'sap:',          // UIレイアウトメタデータ（HintSize等）
+  'sap2010:',      // ViewState関連メタデータ（WorkflowViewState.IdRef等）
 ];
 
 export class DiffCalculator {

--- a/src/parser/xaml-parser.ts
+++ b/src/parser/xaml-parser.ts
@@ -138,6 +138,7 @@ export class XamlParser {
 
       // プロパティ要素（タイプ名.プロパティ名形式）
       if (childName.includes('.')) {
+        if (this.isMetadataElement(child)) return; // メタデータ要素は除外
         const [, propName] = childName.split('.');
         properties[propName] = this.extractPropertyValue(child);
       }


### PR DESCRIPTION
## 変更内容

ViewState関連のプロパティ（`sap2010:WorkflowViewState.IdRef` や `WorkflowViewStateService.ViewState` 子要素）を差分表示から除外する。

### 変更点

- `IGNORED_PROPERTY_PREFIXES` に `sap2010:` プレフィックスを追加
- XAMLパーサーのプロパティ抽出時にメタデータ要素（`WorkflowViewStateService.ViewState`）を除外するチェックを追加

Closes #114