### PR TITLE
fix: 差分表示のプロパティ変更ヘッダーを削除

### DIFF
--- a/packages/shared/renderer/diff-renderer.ts
+++ b/packages/shared/renderer/diff-renderer.ts
@@ -435,11 +435,6 @@ export class DiffRenderer {
     const changesDiv = document.createElement('div');
     changesDiv.className = 'property-changes';
 
-    const header = document.createElement('div');
-    header.className = 'changes-header';
-    header.textContent = `プロパティ変更 (${changes.length})`;
-    changesDiv.appendChild(header);
-
     const changesList = document.createElement('div');
     changesList.className = 'property-diff-detail';
 

--- a/src/renderer/diff-renderer.ts
+++ b/src/renderer/diff-renderer.ts
@@ -86,11 +86,6 @@ export class DiffRenderer {
     const changesDiv = document.createElement('div');
     changesDiv.className = 'property-changes';
 
-    const header = document.createElement('div');
-    header.className = 'changes-header';
-    header.textContent = `プロパティ変更 (${changes.length})`;
-    changesDiv.appendChild(header);
-
     const changesList = document.createElement('div');
     changesList.className = 'property-diff-detail';
 


### PR DESCRIPTION
## Summary
- 差分表示の「プロパティ変更 (N)」ヘッダーを削除
- 個別のプロパティ変更（DisplayName、Annotation等）はそのまま表示を維持

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)