### PR TITLE
差分表示のタイトルを簡潔化

### DIFF
--- a/packages/shared/renderer/diff-renderer.ts
+++ b/packages/shared/renderer/diff-renderer.ts
@@ -91,7 +91,7 @@ export class DiffRenderer {
     const title = document.createElement('span');
     title.className = 'activity-title';
 
-    title.innerHTML = `${icon} ${diffActivity.activity.type}: ${diffActivity.activity.displayName} ${badge}`;
+    title.innerHTML = `${diffActivity.activity.type}: ${diffActivity.activity.displayName} ${badge}`;
 
     header.appendChild(title);
 


### PR DESCRIPTION
## 変更内容

差分表示のアクティビティタイトルを簡潔にしました。

- アイコン（`[=]` など）の表示を削除
- DisplayName 変更時の旧名→新名表示を削除し、新名のみ表示するように変更

Closes #122