### PR TITLE
Assign変更時の表示を統合形式に変更

### DIFF
--- a/packages/shared/renderer/diff-renderer.ts
+++ b/packages/shared/renderer/diff-renderer.ts
@@ -538,41 +538,32 @@ export class DiffRenderer {
     const container = document.createElement('div');
     container.className = 'property-changes';
 
-    // To/Valueの変更を「左辺/右辺」ラベル付きでGitHub風diff表示
-    const assignChanges = diffActivity.changes?.filter(
+    const beforeAct = diffActivity.beforeActivity;  // 変更前のアクティビティ
+    const afterAct = diffActivity.activity;         // 変更後のアクティビティ
+
+    // To/Valueのいずれかが変更されていれば統合形式で表示
+    const hasAssignChange = diffActivity.changes?.some(
       c => c.propertyName === 'To' || c.propertyName === 'Value'
-    ) || [];
+    );
 
-    assignChanges.forEach(change => {
-      const item = document.createElement('div');
-      item.className = 'property-change-item';
+    if (hasAssignChange && beforeAct) {
+      const beforeTo = beforeAct.properties['To'];      // 変更前の左辺
+      const beforeVal = beforeAct.properties['Value'];  // 変更前の右辺
+      const afterTo = afterAct.properties['To'];        // 変更後の左辺
+      const afterVal = afterAct.properties['Value'];    // 変更後の右辺
 
-      // 左辺/右辺のラベル
-      const sideLabel = document.createElement('span');
-      const isLeft = change.propertyName === 'To';  // Toは左辺、Valueは右辺
-      sideLabel.className = `assign-change-side ${isLeft ? 'left' : 'right'}`;
-      sideLabel.textContent = isLeft ? '左辺' : '右辺';
+      // 変更前の行（赤）
+      const beforeDiv = document.createElement('div');
+      beforeDiv.className = 'diff-before';
+      beforeDiv.textContent = `- ${this.formatValue(beforeTo)} = ${this.formatValue(beforeVal)}`;
+      container.appendChild(beforeDiv);
 
-      const propLabel = document.createElement('span');
-      propLabel.className = 'assign-change-label';
-      propLabel.textContent = ` (${change.propertyName}):`;
-
-      // 変更前の値（赤）
-      const beforeValue = document.createElement('div');
-      beforeValue.className = 'diff-before';
-      beforeValue.textContent = `- ${this.formatValue(change.before)}`;
-
-      // 変更後の値（緑）
-      const afterValue = document.createElement('div');
-      afterValue.className = 'diff-after';
-      afterValue.textContent = `+ ${this.formatValue(change.after)}`;
-
-      item.appendChild(sideLabel);
-      item.appendChild(propLabel);
-      item.appendChild(beforeValue);
-      item.appendChild(afterValue);
-      container.appendChild(item);
-    });
+      // 変更後の行（緑）
+      const afterDiv = document.createElement('div');
+      afterDiv.className = 'diff-after';
+      afterDiv.textContent = `+ ${this.formatValue(afterTo)} = ${this.formatValue(afterVal)}`;
+      container.appendChild(afterDiv);
+    }
 
     // To/Value以外のプロパティ変更は通常通り表示
     const otherChanges = diffActivity.changes?.filter(

--- a/packages/shared/styles/diff.css
+++ b/packages/shared/styles/diff.css
@@ -206,31 +206,6 @@
   background-color: rgba(215, 58, 73, 0.08);
 }
 
-/* Assign変更詳細 */
-.assign-change-label {
-  font-weight: 600;
-  color: var(--color-fg-muted, #555);
-  margin-bottom: 2px;
-}
-
-.assign-change-side {
-  display: inline-block;
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 12px;
-  font-weight: 600;
-  margin-right: 4px;
-}
-
-.assign-change-side.left {
-  background-color: #e3f2fd;                     /* 青系: 左辺 */
-  color: #1565c0;
-}
-
-.assign-change-side.right {
-  background-color: #f3e5f5;                     /* 紫系: 右辺 */
-  color: #7b1fa2;
-}
 
 /* セレクト */
 .select {


### PR DESCRIPTION
## 概要

Assignアクティビティの差分表示（modified時）で、左辺(To)と右辺(Value)を別々に表示していたのを、追加/削除時と同じ `To = Value` の統合形式に統一。

## 変更内容

- `renderAssignChanges()` を書き換え: `beforeActivity`/`activity` から To/Value を取得し `- oldTo = oldValue` / `+ newTo = newValue` 形式で表示
- 不要になったCSS（`.assign-change-side`, `.assign-change-label`）を削除

Closes #138