### PR TITLE
ネストされたカードのホバーハイライトを最内側のみに制限

### DIFF
--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -195,7 +195,7 @@
   transition: border-color 0.2s, box-shadow 0.2s; /* アニメーション */
 }
 
-#uipath-visualizer-panel .activity-card:hover {
+#uipath-visualizer-panel .activity-card:hover:not(:has(.activity-card:hover)) {
   border-color: var(--panel-accent);        /* ホバー時のボーダー色 */
   box-shadow: 0 2px 6px rgba(0, 120, 212, 0.2);
 }

--- a/packages/shared/styles/main.css
+++ b/packages/shared/styles/main.css
@@ -149,7 +149,7 @@ body {
   transition: border-color 0.2s, box-shadow 0.2s; /* アニメーション */
 }
 
-.activity-card:hover {
+.activity-card:hover:not(:has(.activity-card:hover)) {
   border-color: #0078d4;                        /* ホバー時のボーダー色 */
   box-shadow: 0 2px 6px rgba(0, 120, 212, 0.2);
 }


### PR DESCRIPTION
## 概要

ネストされた `.activity-card` にホバーした際、親カードまで青くハイライトされてしまう問題を修正。

CSS `:has()` セレクタを使用し、最も内側のホバー中カードのみにハイライトを適用するようにした。

## 変更内容

- `github-panel.css`: `#uipath-visualizer-panel .activity-card:hover` → `:hover:not(:has(.activity-card:hover))`
- `main.css`: `.activity-card:hover` → `:hover:not(:has(.activity-card:hover))`

Closes #153