### PR TITLE
diff-beforeとdiff-afterのpadding・marginを削除

### DIFF
--- a/packages/shared/styles/diff.css
+++ b/packages/shared/styles/diff.css
@@ -127,16 +127,13 @@
 .diff-before {
   color: #d73a49;                               /* 赤: 削除された値 */
   font-family: 'Courier New', monospace;
-  padding: 4px;
   background-color: #ffeef0;
   border-radius: 4px;
-  margin-bottom: 4px;
 }
 
 .diff-after {
   color: #28a745;                               /* 緑: 追加された値 */
   font-family: 'Courier New', monospace;
-  padding: 4px;
   background-color: #f0fff4;
   border-radius: 4px;
 }

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -446,16 +446,13 @@
 #uipath-visualizer-panel .diff-before {
   color: var(--diff-removed-fg);            /* 赤: 削除された値 */
   font-family: 'Courier New', monospace;
-  padding: 4px;
   background-color: var(--diff-removed-bg); /* 薄い赤の背景 */
   border-radius: 4px;
-  margin-bottom: 4px;
 }
 
 #uipath-visualizer-panel .diff-after {
   color: var(--diff-added-fg);              /* 緑: 追加された値 */
   font-family: 'Courier New', monospace;
-  padding: 4px;
   background-color: var(--diff-added-bg);   /* 薄い緑の背景 */
   border-radius: 4px;
 }

--- a/src/styles/diff.css
+++ b/src/styles/diff.css
@@ -127,16 +127,13 @@
 .diff-before {
   color: #d73a49;                               /* 赤: 削除された値 */
   font-family: 'Courier New', monospace;
-  padding: 4px;
   background-color: #ffeef0;
   border-radius: 4px;
-  margin-bottom: 4px;
 }
 
 .diff-after {
   color: #28a745;                               /* 緑: 追加された値 */
   font-family: 'Courier New', monospace;
-  padding: 4px;
   background-color: #f0fff4;
   border-radius: 4px;
 }


### PR DESCRIPTION
## 概要

差分表示の `.diff-before` と `.diff-after` 間の不要な `padding` と `margin` を削除し、before/after が隙間なく表示されるようにした。

## 変更内容

- `.diff-before` から `padding: 4px` と `margin-bottom: 4px` を削除
- `.diff-after` から `padding: 4px` を削除
- 3つの CSS ファイルに同じ変更を適用:
  - `packages/shared/styles/diff.css`
  - `packages/shared/styles/github-panel.css`
  - `src/styles/diff.css`

Closes #157