### PR TITLE
注釈をアクティビティカードにデフォルトで表示

### DIFF
--- a/packages/shared/renderer/diff-renderer.ts
+++ b/packages/shared/renderer/diff-renderer.ts
@@ -96,6 +96,12 @@ export class DiffRenderer {
 
     card.appendChild(header);
 
+    // 注釈表示（DisplayNameの直後に表示）
+    if (diffActivity.activity.annotations) {
+      const annotationDiv = this.renderAnnotation(diffActivity.activity.annotations); // 注釈をレンダリング
+      card.appendChild(annotationDiv);
+    }
+
     // Assignアクティビティの代入式を表示（追加・削除の場合）
     if ((diffActivity.diffType === DiffType.ADDED || diffActivity.diffType === DiffType.REMOVED)
         && diffActivity.activity.type === 'Assign') {
@@ -130,6 +136,16 @@ export class DiffRenderer {
     const key = buildActivityKey(diffActivity.activity, this.activityIndex); // 組み込みキー生成
     this.activityIndex++;
     return key;
+  }
+
+  /**
+   * 注釈をレンダリング（メモ風表示）
+   */
+  private renderAnnotation(text: string): HTMLElement {
+    const div = document.createElement('div'); // 注釈コンテナ
+    div.className = 'activity-annotation'; // メモ風スタイル用クラス
+    div.textContent = text; // 注釈テキストを設定
+    return div;
   }
 
   // ========== 既存メソッド ==========

--- a/packages/shared/renderer/sequence-renderer.ts
+++ b/packages/shared/renderer/sequence-renderer.ts
@@ -81,6 +81,12 @@ export class SequenceRenderer {
 
     card.appendChild(header);
 
+    // 注釈表示（DisplayNameの直後に表示）
+    if (activity.annotations) {
+      const annotationDiv = this.renderAnnotation(activity.annotations); // 注釈をレンダリング
+      card.appendChild(annotationDiv);
+    }
+
     // プロパティ表示
     if (Object.keys(activity.properties).length > 0) {
       const propsDiv = this.renderProperties(activity.properties, activity.type); // アクティビティタイプを渡す
@@ -196,6 +202,16 @@ export class SequenceRenderer {
 
     // 表示可能なプロパティがない場合はnullを返す
     return hasVisibleProps ? propsDiv : null;
+  }
+
+  /**
+   * 注釈をレンダリング（メモ風表示）
+   */
+  private renderAnnotation(text: string): HTMLElement {
+    const div = document.createElement('div'); // 注釈コンテナ
+    div.className = 'activity-annotation'; // メモ風スタイル用クラス
+    div.textContent = text; // 注釈テキストを設定
+    return div;
   }
 
   /**

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -302,8 +302,21 @@
 }
 
 #uipath-visualizer-panel .activity-card.collapsed > .activity-properties,
-#uipath-visualizer-panel .activity-card.collapsed > .informative-screenshot {
-  display: none;                            /* プロパティとスクリーンショットも非表示 */
+#uipath-visualizer-panel .activity-card.collapsed > .informative-screenshot,
+#uipath-visualizer-panel .activity-card.collapsed > .activity-annotation {
+  display: none;                            /* プロパティ・スクリーンショット・注釈も非表示 */
+}
+
+/* ========== 注釈表示 ========== */
+
+#uipath-visualizer-panel .activity-annotation {
+  padding: 2px 6px;                        /* パディング */
+  font-size: 12px;                         /* フォントサイズ */
+  font-style: italic;                      /* イタリック体 */
+  color: var(--panel-text-muted);          /* 控えめテキスト色 */
+  line-height: 1.4;                        /* 行高 */
+  white-space: pre-wrap;                   /* 改行を保持 */
+  word-break: break-word;                  /* 長い単語を折り返す */
 }
 
 /* ========== 差分サマリー ========== */

--- a/packages/shared/styles/main.css
+++ b/packages/shared/styles/main.css
@@ -220,8 +220,20 @@ body {
 }
 
 .activity-card.collapsed > .activity-properties,
-.activity-card.collapsed > .informative-screenshot {
-  display: none;                                /* プロパティとスクリーンショットも非表示 */
+.activity-card.collapsed > .informative-screenshot,
+.activity-card.collapsed > .activity-annotation {
+  display: none;                                /* プロパティ・スクリーンショット・注釈も非表示 */
+}
+
+/* 注釈表示 */
+.activity-annotation {
+  padding: 2px 6px;                            /* パディング */
+  font-size: 12px;                             /* フォントサイズ */
+  font-style: italic;                          /* イタリック体 */
+  color: #666;                                 /* 控えめテキスト色 */
+  line-height: 1.4;                            /* 行高 */
+  white-space: pre-wrap;                       /* 改行を保持 */
+  word-break: break-word;                      /* 長い単語を折り返す */
 }
 
 /* InformativeScreenshot */


### PR DESCRIPTION
## 概要

注釈(Annotation)をアクティビティカードの DisplayName 直後にデフォルトで表示するようにした。

## 変更内容

- `sequence-renderer.ts`: 通常ビューのアクティビティカードに注釈をインライン表示
- `diff-renderer.ts`: 差分ビューのアクティビティカードに注釈をインライン表示
- `main.css`: スタンドアロンビューア用の注釈スタイル追加
- `github-panel.css`: GitHub拡張機能用の注釈スタイル追加（ライト/ダーク/Autoモード対応）

## スタイル

- イタリック体・控えめテキスト色のシンプルな表示
- 折りたたみ時は非表示

Closes #169