### PR TITLE
プロパティ値のテキスト色をデフォルトテキスト色に変更

### DIFF
--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -286,7 +286,7 @@
 }
 
 #uipath-visualizer-panel .property-value {
-  color: var(--panel-accent);               /* アクセント色 */
+  color: var(--panel-text-primary);         /* テキスト色 */
   word-break: break-all;                    /* 長い値を折り返す */
 }
 

--- a/packages/shared/styles/main.css
+++ b/packages/shared/styles/main.css
@@ -204,7 +204,7 @@ body {
 }
 
 .property-value {
-  color: #0078d4;
+  color: #333;
   word-break: break-all;                        /* 長い値を折り返す */
 }
 


### PR DESCRIPTION
## 概要

全アクティビティのプロパティ値（`.property-value`）のテキスト色がアクセント色（青 `#0078d4`）に設定されていたのを、デフォルトのテキスト色に変更。

## 変更内容

- `github-panel.css`: `.property-value` の色を `var(--panel-accent)` → `var(--panel-text-primary)` に変更
- `main.css`: `.property-value` の色を `#0078d4` → `#333` に変更

ライトモードでは黒（`#333`）、ダークモードでは白（`#f0f6fc`）で表示されるようになります。

Closes #171