### PR TITLE
日本語/英語の言語切替機能を追加

### DIFF
--- a/packages/github-extension/manifest.json
+++ b/packages/github-extension/manifest.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "GitHub上でUiPath XAMLファイルを視覚的に表示するChrome拡張機能",
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
   "host_permissions": [
     "https://github.com/*",

--- a/packages/shared/i18n/i18n.ts
+++ b/packages/shared/i18n/i18n.ts
@@ -1,0 +1,87 @@
+// === 言語型定義 ===
+export type Language = 'en' | 'ja'; // 対応言語
+
+// === 言語状態管理（モジュールレベルシングルトン） ===
+let currentLanguage: Language = 'en'; // デフォルトは英語
+
+export function setLanguage(lang: Language): void { // 言語を設定
+	currentLanguage = lang;
+}
+
+export function getLanguage(): Language { // 現在の言語を取得
+	return currentLanguage;
+}
+
+// === アクティビティタイプの日本語マップ（英語はXAMLの値をそのまま使用） ===
+const activityTypeMap: Record<string, string> = {
+	'Sequence': 'シーケンス', // シーケンスアクティビティ
+	'Flowchart': 'フローチャート', // フローチャートアクティビティ
+	'Assign': '代入', // 代入アクティビティ
+	'MultipleAssign': '複数代入', // 複数代入アクティビティ
+	'If': '条件分岐', // 条件分岐アクティビティ
+	'While': '繰り返し（While）', // Whileループ
+	'DoWhile': '繰り返し（DoWhile）', // DoWhileループ
+	'ForEach': '繰り返し（ForEach）', // ForEachループ
+	'Switch': 'スイッチ', // スイッチアクティビティ
+	'TryCatch': 'トライキャッチ', // 例外処理アクティビティ
+	'Click': 'クリック', // クリックアクティビティ
+	'TypeInto': '文字を入力', // 文字入力アクティビティ
+	'GetText': 'テキストを取得', // テキスト取得アクティビティ
+	'LogMessage': 'メッセージをログ', // ログメッセージアクティビティ
+	'InvokeWorkflowFile': 'ワークフローを呼び出し', // ワークフロー呼び出し
+	'Delay': '待機', // 待機アクティビティ
+	'MessageBox': 'メッセージボックス', // メッセージボックスアクティビティ
+	'InputDialog': '入力ダイアログ', // 入力ダイアログアクティビティ
+	'WriteLn': '行を書き込み', // 行書き込みアクティビティ
+	// N系アクティビティ（モダンデザイン）
+	'NApplicationCard': 'アプリケーションカード', // モダンアプリケーションカード
+	'NClick': 'クリック（モダン）', // モダンクリック
+	'NTypeInto': '文字を入力（モダン）', // モダン文字入力
+	'NGetText': 'テキストを取得（モダン）', // モダンテキスト取得
+};
+
+// === プロパティ名の日本語マップ ===
+const propertyNameMap: Record<string, string> = {
+	'To': '代入先', // 代入先プロパティ
+	'Value': '値', // 値プロパティ
+	'Condition': '条件', // 条件プロパティ
+	'Selector': 'セレクター', // セレクタープロパティ
+	'Message': 'メッセージ', // メッセージプロパティ
+	'Level': 'レベル', // ログレベルプロパティ
+	'DisplayName': '表示名', // 表示名プロパティ
+};
+
+// === UI文字列の翻訳マップ（en/ja両方持つ） ===
+const uiStringsMap: Record<string, Record<Language, string>> = {
+	'Added': { en: 'Added', ja: '追加' }, // 差分バッジ: 追加
+	'Removed': { en: 'Removed', ja: '削除' }, // 差分バッジ: 削除
+	'Modified': { en: 'Modified', ja: '変更' }, // 差分バッジ: 変更
+	'Properties': { en: 'Properties', ja: 'プロパティ' }, // 詳細パネル: プロパティ
+	'Annotations': { en: 'Annotations', ja: '注釈' }, // 詳細パネル: 注釈
+	'Screenshot Changed:': { en: 'Screenshot Changed:', ja: 'スクリーンショット変更:' }, // スクリーンショット変更ラベル
+	'Before': { en: 'Before', ja: '変更前' }, // Before ラベル
+	'After': { en: 'After', ja: '変更後' }, // After ラベル
+	'Changed': { en: 'Changed', ja: '変更' }, // バッジ: Changed
+	'Unchanged': { en: 'Unchanged', ja: '未変更' }, // バッジ: Unchanged
+	'New': { en: 'New', ja: '新規' }, // バッジ: New
+	'Deleted': { en: 'Deleted', ja: '削除済' }, // バッジ: Deleted
+	'Deleted File': { en: 'Deleted File', ja: '削除済ファイル' }, // 削除ファイルラベル
+	'New File': { en: 'New File', ja: '新規ファイル' }, // 新規ファイルラベル
+};
+
+// === 翻訳関数 ===
+
+export function translateActivityType(type: string): string { // アクティビティタイプを翻訳
+	if (currentLanguage === 'en') return type; // 英語はXAMLの値をそのまま
+	return activityTypeMap[type] || type; // 日本語訳がなければ英語のまま
+}
+
+export function translatePropertyName(name: string): string { // プロパティ名を翻訳
+	if (currentLanguage === 'en') return name; // 英語はそのまま
+	return propertyNameMap[name] || name; // 日本語訳がなければ英語のまま
+}
+
+export function t(key: string): string { // UI文字列を翻訳
+	const entry = uiStringsMap[key]; // 翻訳マップを検索
+	return entry ? entry[currentLanguage] : key; // 見つからなければキーをそのまま返す
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -9,6 +9,10 @@ export type { ScreenshotPathResolver } from './renderer/sequence-renderer'; // �
 export { TreeViewRenderer } from './renderer/tree-view-renderer'; // ツリービュークラス
 export { DiffRenderer } from './renderer/diff-renderer'; // 差分表示レンダリングクラス
 
+// i18n（国際化）のエクスポート
+export { setLanguage, getLanguage, translateActivityType, translatePropertyName, t } from './i18n/i18n'; // 翻訳関数
+export type { Language } from './i18n/i18n'; // 言語型
+
 // 型定義のエクスポート
 export type { Activity, ParsedXaml, Variable, Argument } from './parser/xaml-parser'; // 型定義
 export type { DiffResult, DiffActivity, DiffType, PropertyChange } from './parser/diff-calculator'; // 差分型定義

--- a/packages/shared/renderer/diff-renderer.ts
+++ b/packages/shared/renderer/diff-renderer.ts
@@ -1,6 +1,7 @@
 import { DiffResult, DiffActivity, DiffType, PropertyChange, buildActivityKey } from '../parser/diff-calculator';
 import { Activity } from '../parser/xaml-parser';
 import { ActivityLineIndex } from '../parser/line-mapper'; // 行番号マッピング型
+import { translateActivityType, translatePropertyName, t } from '../i18n/i18n'; // i18n翻訳関数
 
 /**
  * 差分レンダラー
@@ -72,7 +73,7 @@ export class DiffRenderer {
     const title = document.createElement('span');
     title.className = 'activity-title';
 
-    title.innerHTML = `${diffActivity.activity.type}: ${diffActivity.activity.displayName} ${badge}`;
+    title.innerHTML = `${translateActivityType(diffActivity.activity.type)}: ${diffActivity.activity.displayName} ${badge}`; // アクティビティタイプを翻訳
 
     header.appendChild(title);
 
@@ -184,7 +185,7 @@ export class DiffRenderer {
       // プロパティ名
       const propName = document.createElement('div');
       propName.className = 'prop-name';
-      propName.textContent = `${change.propertyName}:`;
+      propName.textContent = `${translatePropertyName(change.propertyName)}:`; // プロパティ名を翻訳
 
       // Before値（ワードレベルdiff付き）
       const beforeText = this.formatValue(change.before); // 変更前テキスト
@@ -231,7 +232,7 @@ export class DiffRenderer {
 
     const header = document.createElement('div');
     header.className = 'screenshot-header';
-    header.textContent = 'Screenshot Changed:';
+    header.textContent = t('Screenshot Changed:'); // スクリーンショット変更ラベルを翻訳
 
     const compareContainer = document.createElement('div');
     compareContainer.className = 'compare-container';
@@ -242,8 +243,8 @@ export class DiffRenderer {
       const beforeDiv = document.createElement('div');
       beforeDiv.className = 'screenshot-before';
       beforeDiv.innerHTML = `
-        <div class="label">Before</div>
-        <img src="${this.screenshotPathResolver(beforeScreenshot)}" alt="Before" />
+        <div class="label">${t('Before')}</div>
+        <img src="${this.screenshotPathResolver(beforeScreenshot)}" alt="${t('Before')}" />
       `;
       compareContainer.appendChild(beforeDiv);
     }
@@ -254,8 +255,8 @@ export class DiffRenderer {
       const afterDiv = document.createElement('div');
       afterDiv.className = 'screenshot-after';
       afterDiv.innerHTML = `
-        <div class="label">After</div>
-        <img src="${this.screenshotPathResolver(afterScreenshot)}" alt="After" />
+        <div class="label">${t('After')}</div>
+        <img src="${this.screenshotPathResolver(afterScreenshot)}" alt="${t('After')}" />
       `;
       compareContainer.appendChild(afterDiv);
     }
@@ -512,9 +513,9 @@ export class DiffRenderer {
    */
   private getDiffBadge(diffType: DiffType): string {
     const badgeMap: Record<DiffType, string> = {
-      [DiffType.ADDED]: '<span class="badge badge-added">+ Added</span>',
-      [DiffType.REMOVED]: '<span class="badge badge-removed">- Removed</span>',
-      [DiffType.MODIFIED]: '<span class="badge badge-modified">~ Modified</span>'
+      [DiffType.ADDED]: `<span class="badge badge-added">+ ${t('Added')}</span>`, // 追加バッジを翻訳
+      [DiffType.REMOVED]: `<span class="badge badge-removed">- ${t('Removed')}</span>`, // 削除バッジを翻訳
+      [DiffType.MODIFIED]: `<span class="badge badge-modified">~ ${t('Modified')}</span>` // 変更バッジを翻訳
     };
 
     return badgeMap[diffType];

--- a/packages/shared/renderer/sequence-renderer.ts
+++ b/packages/shared/renderer/sequence-renderer.ts
@@ -1,6 +1,7 @@
 import { Activity } from '../parser/xaml-parser';
 import { ActivityLineIndex } from '../parser/line-mapper'; // 行番号マッピング型
 import { buildActivityKey } from '../parser/diff-calculator'; // アクティビティキー生成
+import { translateActivityType, translatePropertyName, t } from '../i18n/i18n'; // i18n翻訳関数
 
 /**
  * Sequenceワークフローのレンダラー
@@ -53,7 +54,7 @@ export class SequenceRenderer {
 
     const title = document.createElement('span');
     title.className = 'activity-title';
-    title.textContent = `${activity.type}: ${activity.displayName}`;
+    title.textContent = `${translateActivityType(activity.type)}: ${activity.displayName}`; // アクティビティタイプを翻訳
 
     header.appendChild(title);
 
@@ -168,7 +169,7 @@ export class SequenceRenderer {
 
           const otherKey = document.createElement('span');
           otherKey.className = 'property-key';
-          otherKey.textContent = `${key}:`;
+          otherKey.textContent = `${translatePropertyName(key)}:`; // プロパティ名を翻訳
 
           const otherValue = document.createElement('span');
           otherValue.className = 'property-value';
@@ -212,7 +213,7 @@ export class SequenceRenderer {
 
         const levelKey = document.createElement('span'); // ラベル
         levelKey.className = 'property-key';
-        levelKey.textContent = 'Level:';
+        levelKey.textContent = `${translatePropertyName('Level')}:`; // プロパティ名を翻訳
 
         const levelValue = document.createElement('span'); // レベル値
         levelValue.className = 'property-value';
@@ -231,7 +232,7 @@ export class SequenceRenderer {
 
         const msgKey = document.createElement('span'); // ラベル
         msgKey.className = 'property-key';
-        msgKey.textContent = 'Message:';
+        msgKey.textContent = `${translatePropertyName('Message')}:`; // プロパティ名を翻訳
 
         const msgValue = document.createElement('span'); // メッセージ値
         msgValue.className = 'property-value';
@@ -257,7 +258,7 @@ export class SequenceRenderer {
 
         const propKey = document.createElement('span');
         propKey.className = 'property-key';
-        propKey.textContent = `${key}:`;
+        propKey.textContent = `${translatePropertyName(key)}:`; // プロパティ名を翻訳
 
         const propValue = document.createElement('span');
         propValue.className = 'property-value';
@@ -331,16 +332,16 @@ export class SequenceRenderer {
     // 詳細情報をレンダリング
     detailContent.innerHTML = `
       <div class="detail-section">
-        <h4>${activity.type}</h4>
-        <p><strong>DisplayName:</strong> ${activity.displayName}</p>
+        <h4>${translateActivityType(activity.type)}</h4>
+        <p><strong>${translatePropertyName('DisplayName')}:</strong> ${activity.displayName}</p>
       </div>
       <div class="detail-section">
-        <h4>Properties</h4>
+        <h4>${t('Properties')}</h4>
         ${this.renderAllProperties(activity.properties)}
       </div>
       ${activity.annotations ? `
         <div class="detail-section">
-          <h4>Annotations</h4>
+          <h4>${t('Annotations')}</h4>
           <p>${activity.annotations}</p>
         </div>
       ` : ''}
@@ -356,7 +357,7 @@ export class SequenceRenderer {
     return Object.entries(properties)
       .map(([key, value]) => `
         <div class="property-row">
-          <span class="prop-key">${key}:</span>
+          <span class="prop-key">${translatePropertyName(key)}:</span>
           <span class="prop-value">${this.formatValue(value)}</span>
         </div>
       `)

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -586,6 +586,25 @@
   gap: 8px;                                 /* ボタン間の間隔 */
 }
 
+/* 言語切替ボタン */
+#uipath-visualizer-panel .panel-lang-toggle {
+  font-size: 12px;                          /* 小さめのフォント */
+  font-weight: 600;                         /* 太字 */
+  padding: 2px 8px;                         /* コンパクトなパディング */
+  border: 1px solid var(--panel-border);    /* ボーダー */
+  border-radius: 4px;                       /* 角丸 */
+  background-color: var(--panel-bg-secondary); /* セカンダリ背景 */
+  color: var(--panel-text-secondary);       /* テキスト色 */
+  cursor: pointer;                          /* クリック可能カーソル */
+  transition: border-color 0.2s, color 0.2s; /* ホバーアニメーション */
+  white-space: nowrap;                      /* 折り返さない */
+}
+
+#uipath-visualizer-panel .panel-lang-toggle:hover {
+  border-color: var(--panel-accent);        /* ホバー時のボーダー色 */
+  color: var(--panel-accent);               /* ホバー時のテキスト色 */
+}
+
 /* Copy HTMLボタン（デバッグ用・控えめ表示） */
 #uipath-visualizer-panel .panel-copy-btn {
   opacity: 0.7;                             /* 控えめな透明度 */


### PR DESCRIPTION
## 概要

UiPath XAML Visualizer に日本語/英語の言語切替機能を追加しました。

## 変更内容

- **i18n モジュール新規作成** (`packages/shared/i18n/i18n.ts`)
  - アクティビティタイプ（Sequence→シーケンス、Assign→代入 等）の翻訳マップ
  - プロパティ名（To→代入先、Value→値 等）の翻訳マップ
  - UI文字列（Added→追加、Properties→プロパティ 等）の翻訳マップ
  - `translateActivityType()`, `translatePropertyName()`, `t()` 翻訳関数

- **レンダラーへのi18n適用**
  - `sequence-renderer.ts`: アクティビティタイプ、プロパティ名、詳細パネルの翻訳
  - `diff-renderer.ts`: 差分バッジ、スクリーンショットラベル、プロパティ名の翻訳

- **言語切替UI**
  - パネルヘッダーに「日本語」/「English」トグルボタンを配置
  - `chrome.storage.sync` で設定を永続化
  - 言語変更時にパネル全体を再レンダリング

- **その他**
  - `manifest.json` に `storage` 権限を追加
  - content.ts 内のハードコード文字列を `t()` で翻訳対応

Closes #183