### PR TITLE
プロパティサブパネルの実装 (#187)

### DIFF
--- a/packages/github-extension/src/content.ts
+++ b/packages/github-extension/src/content.ts
@@ -1606,6 +1606,15 @@ function applyDiffHighlights(container: HTMLElement, diffResult: any): void {
 				if (propsDiv) {
 					(propsDiv as HTMLElement).style.display = 'none'; // 重複を防ぐため非表示
 				}
+				// サブプロパティパネルのトグル・パネルも非表示にする
+				const subToggle = card.querySelector(':scope > .property-sub-panel-toggle'); // サブパネルトグル
+				if (subToggle) {
+					(subToggle as HTMLElement).style.display = 'none'; // 非表示
+				}
+				const subPanel = card.querySelector(':scope > .property-sub-panel'); // サブパネル本体
+				if (subPanel) {
+					(subPanel as HTMLElement).style.display = 'none'; // 非表示
+				}
 
 				// To/Value以外のプロパティ変更は通常通り表示
 				const otherChanges = item.changes.filter( // To/Value以外を抽出

--- a/packages/shared/i18n/i18n.ts
+++ b/packages/shared/i18n/i18n.ts
@@ -49,6 +49,23 @@ const propertyNameMap: Record<string, string> = {
 	'Message': 'メッセージ', // メッセージプロパティ
 	'Level': 'レベル', // ログレベルプロパティ
 	'DisplayName': '表示名', // 表示名プロパティ
+	// N系アクティビティのプロパティ名
+	'AttachMode': 'アタッチモード', // アプリケーション接続方法
+	'HealingAgentBehavior': '修復エージェント', // 自動修復エージェント動作
+	'ScopeGuid': 'スコープGUID', // スコープ識別子
+	'Version': 'バージョン', // バージョン情報
+	'ClickType': 'クリック種別', // クリックの種類
+	'MouseButton': 'マウスボタン', // マウスボタン
+	'KeyModifiers': 'キー修飾子', // キー修飾子（Ctrl/Shift等）
+	'ActivateBefore': '事前アクティブ化', // 実行前にウィンドウをアクティブ化
+	'InteractionMode': '操作モード', // 操作モード（Simulate/Hardware等）
+	'TargetApp': 'ターゲットアプリ', // 対象アプリケーション
+	'Target': 'ターゲット', // ターゲット要素
+	'Text': 'テキスト', // テキスト
+	'EmptyField': 'フィールドクリア', // 入力前にフィールドをクリア
+	'DelayBetweenKeys': 'キー間遅延', // キー入力間の遅延
+	'DelayBefore': '実行前遅延', // 実行前の遅延
+	'DelayAfter': '実行後遅延', // 実行後の遅延
 };
 
 // === UI文字列の翻訳マップ（en/ja両方持つ） ===
@@ -67,6 +84,12 @@ const uiStringsMap: Record<string, Record<Language, string>> = {
 	'Deleted': { en: 'Deleted', ja: '削除済' }, // バッジ: Deleted
 	'Deleted File': { en: 'Deleted File', ja: '削除済ファイル' }, // 削除ファイルラベル
 	'New File': { en: 'New File', ja: '新規ファイル' }, // 新規ファイルラベル
+	// サブプロパティパネル用
+	'Input': { en: 'Input', ja: '入力' }, // プロパティグループ: 入力
+	'Options': { en: 'Options', ja: 'オプション' }, // プロパティグループ: オプション
+	'Misc': { en: 'Misc', ja: 'その他' }, // プロパティグループ: その他
+	'Common': { en: 'Common', ja: '共通' }, // プロパティグループ: 共通
+	'Toggle property panel': { en: 'Properties', ja: 'プロパティ' }, // サブパネルトグルボタンラベル
 };
 
 // === 翻訳関数 ===

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -8,6 +8,8 @@ export { SequenceRenderer } from './renderer/sequence-renderer'; // Sequenceレ�
 export type { ScreenshotPathResolver } from './renderer/sequence-renderer'; // スクリーンショットパスリゾルバー型
 export { TreeViewRenderer } from './renderer/tree-view-renderer'; // ツリービュークラス
 export { DiffRenderer } from './renderer/diff-renderer'; // 差分表示レンダリングクラス
+export { isHiddenProperty, getActivityPropertyConfig, getSubProperties, hasSubPanel } from './renderer/property-config'; // プロパティ分類関数
+export type { PropertyGroup, ActivityPropertyConfig } from './renderer/property-config'; // プロパティ分類型
 
 // i18n（国際化）のエクスポート
 export { setLanguage, getLanguage, translateActivityType, translatePropertyName, t } from './i18n/i18n'; // 翻訳関数

--- a/packages/shared/renderer/property-config.ts
+++ b/packages/shared/renderer/property-config.ts
@@ -1,0 +1,118 @@
+// === プロパティ分類設定モジュール ===
+// アクティビティ別にメインプロパティ・サブプロパティ・非表示プロパティを定義
+
+import { t } from '../i18n/i18n'; // UI文字列翻訳
+
+// === 型定義 ===
+
+/** プロパティグループ（UiPath Studio風のカテゴリ） */
+export interface PropertyGroup { // プロパティグループの型
+  label: () => string; // グループ名（翻訳対応のため関数）
+  properties: string[]; // グループに属するプロパティ名一覧
+}
+
+/** アクティビティ別のプロパティ設定 */
+export interface ActivityPropertyConfig { // アクティビティ別設定の型
+  mainProperties: string[]; // メインエリアに表示するプロパティ
+  subGroups: PropertyGroup[]; // サブパネル内のグループ一覧
+}
+
+// === 非表示プロパティ判定 ===
+
+/** メタデータ系プレフィックス（表示不要なXAML属性） */
+const HIDDEN_PREFIXES = [ // 非表示判定用のプレフィックス一覧
+  'sap:', // System.Activities.Presentation名前空間
+  'sap2010:', // System.Activities.Presentation 2010名前空間
+  'xmlns', // XML名前空間宣言
+  'mc:', // Markup Compatibility名前空間
+  'mva:', // Microsoft.VisualBasic.Activities名前空間
+];
+
+/**
+ * メタデータプロパティかどうかを判定
+ * sap:*, sap2010:*, xmlns* 等のXAML内部属性を除外
+ */
+export function isHiddenProperty(name: string): boolean { // プロパティ名を受け取り非表示判定
+  return HIDDEN_PREFIXES.some(prefix => name.startsWith(prefix)); // いずれかのプレフィックスで始まるか
+}
+
+// === アクティビティ別プロパティ設定 ===
+
+/** メインエリアに表示するデフォルトの重要プロパティ */
+const DEFAULT_MAIN_PROPERTIES = ['To', 'Value', 'Condition', 'Selector', 'Message']; // デフォルトのメインプロパティ一覧
+
+/** アクティビティ別の設定マップ */
+const ACTIVITY_CONFIGS: Record<string, ActivityPropertyConfig> = { // アクティビティタイプ → 設定
+  'NApplicationCard': { // モダンアプリケーションカード
+    mainProperties: ['TargetApp'], // メイン: アプリ名（特殊レンダリング）
+    subGroups: [ // サブパネル内のグループ
+      { label: () => t('Input'), properties: ['AttachMode'] }, // 入力グループ
+      { label: () => t('Options'), properties: ['HealingAgentBehavior', 'Version'] }, // オプショングループ
+      { label: () => t('Misc'), properties: ['ScopeGuid'] }, // その他グループ
+    ],
+  },
+  'NClick': { // モダンクリック
+    mainProperties: ['Target'], // メイン: ターゲット
+    subGroups: [ // サブパネル内のグループ
+      { label: () => t('Input'), properties: ['ClickType', 'MouseButton', 'KeyModifiers'] }, // 入力グループ
+      { label: () => t('Options'), properties: ['ActivateBefore', 'InteractionMode'] }, // オプショングループ
+    ],
+  },
+  'NTypeInto': { // モダン文字入力
+    mainProperties: ['Target', 'Text'], // メイン: ターゲット・テキスト
+    subGroups: [ // サブパネル内のグループ
+      { label: () => t('Input'), properties: ['ClickType', 'MouseButton', 'KeyModifiers'] }, // 入力グループ
+      { label: () => t('Options'), properties: ['ActivateBefore', 'InteractionMode', 'EmptyField', 'DelayBetweenKeys', 'DelayBefore', 'DelayAfter'] }, // オプショングループ
+    ],
+  },
+  'NGetText': { // モダンテキスト取得
+    mainProperties: ['Target', 'Value'], // メイン: ターゲット・値
+    subGroups: [ // サブパネル内のグループ
+      { label: () => t('Options'), properties: ['ActivateBefore', 'InteractionMode'] }, // オプショングループ
+    ],
+  },
+};
+
+/**
+ * アクティビティタイプに応じたプロパティ設定を取得
+ * 未登録のアクティビティはデフォルト設定（グループなし）を返す
+ */
+export function getActivityPropertyConfig(type: string): ActivityPropertyConfig { // アクティビティタイプから設定を取得
+  return ACTIVITY_CONFIGS[type] || { // 登録済み設定があればそれを返す
+    mainProperties: DEFAULT_MAIN_PROPERTIES, // デフォルトのメインプロパティ
+    subGroups: [], // デフォルトはグループなし
+  };
+}
+
+/**
+ * サブプロパティを抽出
+ * メインプロパティでもメタデータでもないプロパティを返す
+ */
+export function getSubProperties( // サブプロパティ抽出関数
+  properties: Record<string, any>, // 全プロパティ
+  activityType: string // アクティビティタイプ
+): Record<string, any> { // サブプロパティの連想配列を返す
+  const config = getActivityPropertyConfig(activityType); // 設定を取得
+  const mainSet = new Set(config.mainProperties); // メインプロパティをSetに変換（高速検索）
+  const result: Record<string, any> = {}; // 結果オブジェクト
+
+  for (const [key, value] of Object.entries(properties)) { // 全プロパティをループ
+    if (mainSet.has(key)) continue; // メインプロパティはスキップ
+    if (isHiddenProperty(key)) continue; // メタデータはスキップ
+    if (key === 'DisplayName') continue; // 表示名はヘッダーに表示済み
+    if (key === 'AssignOperations') continue; // MultipleAssignの専用プロパティはスキップ
+    result[key] = value; // サブプロパティとして追加
+  }
+
+  return result; // サブプロパティを返す
+}
+
+/**
+ * アクティビティがサブパネルを持つべきか判定
+ * 専用レンダリング（Assign, MultipleAssign）はサブパネル不要
+ */
+export function hasSubPanel(activityType: string): boolean { // サブパネル要否判定
+  if (activityType === 'Assign') return false; // Assignは専用レンダリング
+  if (activityType === 'MultipleAssign') return false; // MultipleAssignは専用レンダリング
+  return true; // その他はサブパネル対象
+}

--- a/packages/shared/renderer/sequence-renderer.ts
+++ b/packages/shared/renderer/sequence-renderer.ts
@@ -2,6 +2,7 @@ import { Activity } from '../parser/xaml-parser';
 import { ActivityLineIndex } from '../parser/line-mapper'; // 行番号マッピング型
 import { buildActivityKey } from '../parser/diff-calculator'; // アクティビティキー生成
 import { translateActivityType, translatePropertyName, t } from '../i18n/i18n'; // i18n翻訳関数
+import { getSubProperties, getActivityPropertyConfig, hasSubPanel } from './property-config'; // プロパティ分類設定
 
 /**
  * Sequenceワークフローのレンダラー
@@ -103,6 +104,16 @@ export class SequenceRenderer {
       }
     }
 
+    // サブプロパティパネル挿入（メインプロパティの後、スクリーンショットの前）
+    if (hasSubPanel(activity.type) && Object.keys(activity.properties).length > 0) {
+      const subProps = getSubProperties(activity.properties, activity.type); // サブプロパティを抽出
+      if (Object.keys(subProps).length > 0) {
+        const subPanel = this.renderSubPropertyPanel(subProps, activity.type); // サブパネルを生成
+        card.appendChild(subPanel.toggle); // トグルボタンを追加
+        card.appendChild(subPanel.panel); // パネル本体を追加
+      }
+    }
+
     // InformativeScreenshot表示
     if (activity.informativeScreenshot) {
       const screenshotDiv = this.renderScreenshot(activity.informativeScreenshot);
@@ -200,6 +211,56 @@ export class SequenceRenderer {
       });
 
       return propsDiv;
+    }
+
+    // NApplicationCardアクティビティの場合はTargetAppからアプリ名を表示
+    if (activityType === 'NApplicationCard' && properties['TargetApp']) {
+      const appName = this.formatTargetApp(properties['TargetApp']); // アプリ名を抽出
+      if (appName) {
+        const propItem = document.createElement('div'); // アプリ名表示用の行
+        propItem.className = 'property-item';
+
+        const propKey = document.createElement('span'); // ラベル
+        propKey.className = 'property-key';
+        propKey.textContent = `${translatePropertyName('TargetApp')}:`; // プロパティ名を翻訳
+
+        const propValue = document.createElement('span'); // アプリ名値
+        propValue.className = 'property-value';
+        propValue.textContent = appName; // 抽出したアプリ名
+
+        propItem.appendChild(propKey);
+        propItem.appendChild(propValue);
+        propsDiv.appendChild(propItem);
+        return propsDiv;
+      }
+    }
+
+    // NClick/NTypeInto/NGetTextアクティビティの場合はメインプロパティのみ表示
+    if (activityType && activityType.startsWith('N') && activityType !== 'NApplicationCard') {
+      const config = getActivityPropertyConfig(activityType); // アクティビティ別設定を取得
+      let hasVisibleMainProps = false; // メインプロパティがあるかフラグ
+
+      for (const mainKey of config.mainProperties) { // メインプロパティのみループ
+        if (properties[mainKey] !== undefined) {
+          const propItem = document.createElement('div'); // プロパティ行
+          propItem.className = 'property-item';
+
+          const propKey = document.createElement('span'); // ラベル
+          propKey.className = 'property-key';
+          propKey.textContent = `${translatePropertyName(mainKey)}:`; // プロパティ名を翻訳
+
+          const propValue = document.createElement('span'); // 値
+          propValue.className = 'property-value';
+          propValue.textContent = this.formatValue(properties[mainKey]); // フォーマット済み値
+
+          propItem.appendChild(propKey);
+          propItem.appendChild(propValue);
+          propsDiv.appendChild(propItem);
+          hasVisibleMainProps = true;
+        }
+      }
+
+      return hasVisibleMainProps ? propsDiv : null;
     }
 
     // LogMessageアクティビティの場合はLevel/Messageを表示
@@ -362,6 +423,147 @@ export class SequenceRenderer {
         </div>
       `)
       .join('');
+  }
+
+  /**
+   * サブプロパティパネルをレンダリング（トグルボタン + パネル本体）
+   */
+  private renderSubPropertyPanel(
+    subProps: Record<string, any>, // サブプロパティ
+    activityType: string // アクティビティタイプ
+  ): { toggle: HTMLElement; panel: HTMLElement } { // トグルボタンとパネルを返す
+    // トグルボタン
+    const toggle = document.createElement('button'); // トグルボタン要素
+    toggle.className = 'property-sub-panel-toggle'; // CSSクラス
+    toggle.textContent = `${t('Toggle property panel')} ▶`; // ボタンラベル（折りたたみ状態）
+
+    // パネル本体（初期非表示）
+    const panel = document.createElement('div'); // パネル要素
+    panel.className = 'property-sub-panel'; // CSSクラス
+    panel.style.display = 'none'; // 初期非表示
+
+    // アクティビティ設定のグループを取得
+    const config = getActivityPropertyConfig(activityType); // 設定を取得
+
+    if (config.subGroups.length > 0) {
+      // グループ別に表示
+      const groupedKeys = new Set<string>(); // グループに属するキーの集合
+      for (const group of config.subGroups) { // 各グループをループ
+        const groupProps: Record<string, any> = {}; // グループ内のプロパティ
+        for (const propName of group.properties) { // グループ内の各プロパティ名
+          if (subProps[propName] !== undefined) { // サブプロパティに存在するか
+            groupProps[propName] = subProps[propName]; // グループに追加
+            groupedKeys.add(propName); // 使用済みとしてマーク
+          }
+        }
+        if (Object.keys(groupProps).length > 0) { // グループに表示対象があれば
+          const groupDiv = this.renderPropertyGroup(group.label(), groupProps); // グループをレンダリング
+          panel.appendChild(groupDiv); // パネルに追加
+        }
+      }
+
+      // グループに属さないプロパティを「共通」グループで表示
+      const ungrouped: Record<string, any> = {}; // 未グループのプロパティ
+      for (const [key, value] of Object.entries(subProps)) { // サブプロパティ全体をループ
+        if (!groupedKeys.has(key)) { // グループに属していない場合
+          ungrouped[key] = value; // 未グループに追加
+        }
+      }
+      if (Object.keys(ungrouped).length > 0) { // 未グループのプロパティがあれば
+        const commonDiv = this.renderPropertyGroup(t('Common'), ungrouped); // 共通グループとしてレンダリング
+        panel.appendChild(commonDiv); // パネルに追加
+      }
+    } else {
+      // グループなし: フラットにプロパティを表示
+      for (const [key, value] of Object.entries(subProps)) { // サブプロパティ全体をループ
+        const propItem = document.createElement('div'); // プロパティ行
+        propItem.className = 'property-item'; // CSSクラス
+
+        const propKey = document.createElement('span'); // プロパティ名
+        propKey.className = 'property-key'; // CSSクラス
+        propKey.textContent = `${translatePropertyName(key)}:`; // 翻訳済みプロパティ名
+
+        const propValue = document.createElement('span'); // プロパティ値
+        propValue.className = 'property-value'; // CSSクラス
+        propValue.textContent = this.formatValue(value); // フォーマット済み値
+
+        propItem.appendChild(propKey); // 名前を追加
+        propItem.appendChild(propValue); // 値を追加
+        panel.appendChild(propItem); // パネルに追加
+      }
+    }
+
+    // トグルボタンのクリックイベント
+    toggle.addEventListener('click', (e) => {
+      e.stopPropagation(); // カードのクリックイベントを阻止
+      const isExpanded = panel.style.display !== 'none'; // 現在の表示状態を取得
+      panel.style.display = isExpanded ? 'none' : 'block'; // 表示/非表示を切り替え
+      toggle.textContent = isExpanded
+        ? `${t('Toggle property panel')} ▶` // 折りたたみ状態
+        : `${t('Toggle property panel')} ▼`; // 展開状態
+    });
+
+    return { toggle, panel }; // トグルとパネルを返す
+  }
+
+  /**
+   * プロパティグループをレンダリング（UiPath Studio風のカテゴリ表示）
+   */
+  private renderPropertyGroup(label: string, properties: Record<string, any>): HTMLElement { // グループ名とプロパティを受け取る
+    const groupDiv = document.createElement('div'); // グループコンテナ
+    groupDiv.className = 'property-group'; // CSSクラス
+
+    const headerDiv = document.createElement('div'); // グループヘッダー
+    headerDiv.className = 'property-group-header'; // CSSクラス
+    headerDiv.textContent = label; // グループ名
+    groupDiv.appendChild(headerDiv); // ヘッダーを追加
+
+    const bodyDiv = document.createElement('div'); // グループ本体
+    bodyDiv.className = 'property-group-body'; // CSSクラス
+
+    for (const [key, value] of Object.entries(properties)) { // プロパティをループ
+      const propItem = document.createElement('div'); // プロパティ行
+      propItem.className = 'property-item'; // CSSクラス
+
+      const propKey = document.createElement('span'); // プロパティ名
+      propKey.className = 'property-key'; // CSSクラス
+      propKey.textContent = `${translatePropertyName(key)}:`; // 翻訳済みプロパティ名
+
+      const propValue = document.createElement('span'); // プロパティ値
+      propValue.className = 'property-value'; // CSSクラス
+      propValue.textContent = this.formatValue(value); // フォーマット済み値
+
+      propItem.appendChild(propKey); // 名前を追加
+      propItem.appendChild(propValue); // 値を追加
+      bodyDiv.appendChild(propItem); // グループ本体に追加
+    }
+
+    groupDiv.appendChild(bodyDiv); // 本体をグループに追加
+    return groupDiv; // グループ要素を返す
+  }
+
+  /**
+   * TargetAppオブジェクトからアプリ名を抽出
+   * FilePathまたはSelectorのtitle属性からアプリ名を取得
+   */
+  private formatTargetApp(targetApp: any): string { // TargetAppプロパティからアプリ名を抽出
+    if (typeof targetApp === 'string') return targetApp; // 文字列ならそのまま返す
+    if (typeof targetApp !== 'object' || targetApp === null) return ''; // オブジェクト以外は空文字
+
+    // FilePathからアプリ名を取得
+    if (targetApp.FilePath) return String(targetApp.FilePath); // ファイルパスがあればそれを返す
+
+    // Selectorのtitle属性からアプリ名を取得
+    if (targetApp.Selector) {
+      const selector = String(targetApp.Selector); // セレクターを文字列化
+      const titleMatch = selector.match(/title='([^']+)'/); // title属性を抽出
+      if (titleMatch) return titleMatch[1]; // 一致すればtitle値を返す
+    }
+
+    // AppDescriptorからアプリ名を取得
+    if (targetApp.AppDescriptor) return String(targetApp.AppDescriptor); // AppDescriptorがあればそれを返す
+
+    return this.formatValue(targetApp); // フォールバック: JSON文字列化
   }
 
   /**

--- a/packages/shared/styles/github-panel.css
+++ b/packages/shared/styles/github-panel.css
@@ -303,8 +303,75 @@
 
 #uipath-visualizer-panel .activity-card.collapsed > .activity-properties,
 #uipath-visualizer-panel .activity-card.collapsed > .informative-screenshot,
-#uipath-visualizer-panel .activity-card.collapsed > .activity-annotation {
-  display: none;                            /* プロパティ・スクリーンショット・注釈も非表示 */
+#uipath-visualizer-panel .activity-card.collapsed > .activity-annotation,
+#uipath-visualizer-panel .activity-card.collapsed > .property-sub-panel-toggle,
+#uipath-visualizer-panel .activity-card.collapsed > .property-sub-panel {
+  display: none;                            /* プロパティ・スクリーンショット・注釈・サブパネルも非表示 */
+}
+
+/* ========== サブプロパティパネル ========== */
+
+/* トグルボタン */
+#uipath-visualizer-panel .property-sub-panel-toggle {
+  display: block;                           /* ブロック表示（全幅） */
+  width: 100%;                              /* 全幅 */
+  padding: 4px 6px;                         /* パディング */
+  margin-top: 4px;                          /* 上マージン */
+  background: none;                         /* 背景なし */
+  border: 1px dashed var(--panel-border-light); /* 点線ボーダー */
+  border-radius: 4px;                       /* 角丸 */
+  cursor: pointer;                          /* クリック可能カーソル */
+  font-size: 12px;                          /* フォントサイズ */
+  color: var(--panel-text-muted);           /* 控えめテキスト色 */
+  text-align: left;                         /* 左揃え */
+  transition: background-color 0.2s, color 0.2s; /* ホバーアニメーション */
+}
+
+#uipath-visualizer-panel .property-sub-panel-toggle:hover {
+  background-color: var(--panel-hover-bg);  /* ホバー時の背景色 */
+  color: var(--panel-text-secondary);       /* ホバー時のテキスト色 */
+}
+
+/* パネル本体 */
+#uipath-visualizer-panel .property-sub-panel {
+  margin-top: 4px;                          /* 上マージン */
+  padding: 6px;                             /* パディング */
+  background-color: var(--panel-bg-tertiary); /* 薄い背景色 */
+  border: 1px solid var(--panel-border);    /* ボーダー */
+  border-radius: 4px;                       /* 角丸 */
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace; /* 等幅フォント */
+  font-size: 12px;                          /* コード風フォントサイズ */
+  line-height: 20px;                        /* 行高 */
+  font-weight: 400;                         /* 通常ウェイト */
+}
+
+#uipath-visualizer-panel .property-sub-panel .property-key {
+  font-weight: 400;                         /* サブパネル内は太字にしない */
+}
+
+/* プロパティグループ */
+#uipath-visualizer-panel .property-group {
+  display: flex;                            /* 横並びレイアウト */
+  align-items: baseline;                    /* ベースライン揃え */
+  flex-wrap: wrap;                          /* 折り返し可能 */
+  gap: 2px 8px;                             /* 行間・列間 */
+  margin-bottom: 2px;                       /* グループ間の間隔 */
+}
+
+#uipath-visualizer-panel .property-group:last-child {
+  margin-bottom: 0;                         /* 最後のグループは間隔なし */
+}
+
+#uipath-visualizer-panel .property-group-header {
+  font-size: 12px;                          /* コード風フォントサイズ */
+  color: var(--panel-text-secondary);       /* 控えめテキスト色 */
+  white-space: nowrap;                      /* 折り返さない */
+}
+
+#uipath-visualizer-panel .property-group-body {
+  display: flex;                            /* 横並びレイアウト */
+  flex-wrap: wrap;                          /* 折り返し可能 */
+  gap: 2px 8px;                             /* 行間・列間 */
 }
 
 /* ========== スクリーンショット表示 ========== */

--- a/packages/shared/styles/main.css
+++ b/packages/shared/styles/main.css
@@ -221,8 +221,73 @@ body {
 
 .activity-card.collapsed > .activity-properties,
 .activity-card.collapsed > .informative-screenshot,
-.activity-card.collapsed > .activity-annotation {
-  display: none;                                /* プロパティ・スクリーンショット・注釈も非表示 */
+.activity-card.collapsed > .activity-annotation,
+.activity-card.collapsed > .property-sub-panel-toggle,
+.activity-card.collapsed > .property-sub-panel {
+  display: none;                                /* プロパティ・スクリーンショット・注釈・サブパネルも非表示 */
+}
+
+/* サブプロパティパネル トグルボタン */
+.property-sub-panel-toggle {
+  display: block;                               /* ブロック表示（全幅） */
+  width: 100%;                                  /* 全幅 */
+  padding: 4px 6px;                             /* パディング */
+  margin-top: 4px;                              /* 上マージン */
+  background: none;                             /* 背景なし */
+  border: 1px dashed #ccc;                      /* 点線ボーダー */
+  border-radius: 4px;                           /* 角丸 */
+  cursor: pointer;                              /* クリック可能カーソル */
+  font-size: 12px;                              /* フォントサイズ */
+  color: #888;                                  /* 控えめテキスト色 */
+  text-align: left;                             /* 左揃え */
+  transition: background-color 0.2s, color 0.2s; /* ホバーアニメーション */
+}
+
+.property-sub-panel-toggle:hover {
+  background-color: #f0f0f0;                    /* ホバー時の背景色 */
+  color: #555;                                  /* ホバー時のテキスト色 */
+}
+
+/* サブプロパティパネル本体 */
+.property-sub-panel {
+  margin-top: 4px;                              /* 上マージン */
+  padding: 6px;                                 /* パディング */
+  background-color: #f5f5f5;                    /* 薄い背景色 */
+  border: 1px solid #e0e0e0;                    /* ボーダー */
+  border-radius: 4px;                           /* 角丸 */
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace; /* 等幅フォント */
+  font-size: 12px;                              /* コード風フォントサイズ */
+  line-height: 20px;                            /* 行高 */
+  font-weight: 400;                             /* 通常ウェイト（親の太字を上書き） */
+}
+
+.property-sub-panel .property-key {
+  font-weight: 400;                             /* サブパネル内は太字にしない */
+}
+
+/* プロパティグループ */
+.property-group {
+  display: flex;                                /* 横並びレイアウト */
+  align-items: baseline;                        /* ベースライン揃え */
+  flex-wrap: wrap;                              /* 折り返し可能 */
+  gap: 2px 8px;                                 /* 行間・列間 */
+  margin-bottom: 2px;                           /* グループ間の間隔 */
+}
+
+.property-group:last-child {
+  margin-bottom: 0;                             /* 最後のグループは間隔なし */
+}
+
+.property-group-header {
+  font-size: 12px;                              /* コード風フォントサイズ */
+  color: #555;                                  /* 控えめテキスト色 */
+  white-space: nowrap;                          /* 折り返さない */
+}
+
+.property-group-body {
+  display: flex;                                /* 横並びレイアウト */
+  flex-wrap: wrap;                              /* 折り返し可能 */
+  gap: 2px 8px;                                 /* 行間・列間 */
 }
 
 /* 注釈表示 */


### PR DESCRIPTION
## 概要

アクティビティカードに展開可能なサブプロパティパネルを追加。NApplicationCard等のN系アクティビティでメインプロパティとサブプロパティを分離し、グループ化して表示する機能を実装。

## 変更内容

- **property-config.ts（新規）**: アクティビティ別のプロパティ分類モジュール（メイン/サブ/非表示の判定、グループ定義）
- **sequence-renderer.ts**: NApplicationCardのメインプロパティ表示、サブパネル描画メソッド追加
- **main.css / github-panel.css**: サブパネルCSS（トグルボタン、パネル本体、グループ表示、等幅フォント、ダークモード対応）
- **i18n.ts**: N系プロパティ名翻訳 + UIグループ名翻訳
- **index.ts**: property-configのエクスポート追加
- **content.ts**: diff表示時にサブパネルも非表示にする処理追加

Closes #187