### PR TITLE
NApplicationCard・NClickのプロパティ表示を改善

### DIFF
--- a/packages/shared/i18n/i18n.ts
+++ b/packages/shared/i18n/i18n.ts
@@ -61,11 +61,17 @@ const propertyNameMap: Record<string, string> = {
 	'InteractionMode': '操作モード', // 操作モード（Simulate/Hardware等）
 	'TargetApp': 'ターゲットアプリ', // 対象アプリケーション
 	'Target': 'ターゲット', // ターゲット要素
+	'Url': 'URL', // ブラウザURL
+	'ObjectRepository': 'オブジェクトリポジトリ', // オブジェクトリポジトリ連携
 	'Text': 'テキスト', // テキスト
 	'EmptyField': 'フィールドクリア', // 入力前にフィールドをクリア
 	'DelayBetweenKeys': 'キー間遅延', // キー入力間の遅延
 	'DelayBefore': '実行前遅延', // 実行前の遅延
 	'DelayAfter': '実行後遅延', // 実行後の遅延
+	'FullSelectorArgument': '厳密セレクター', // 厳密セレクター（完全一致）
+	'FuzzySelectorArgument': 'あいまいセレクター', // あいまいセレクター（ファジー一致）
+	'CursorMotionType': 'カーソル移動タイプ', // カーソルの移動方法
+	'AlterDisabledElement': '無効な要素を変更', // 無効な要素に対する操作
 };
 
 // === UI文字列の翻訳マップ（en/ja両方持つ） ===
@@ -89,7 +95,11 @@ const uiStringsMap: Record<string, Record<Language, string>> = {
 	'Options': { en: 'Options', ja: 'オプション' }, // プロパティグループ: オプション
 	'Misc': { en: 'Misc', ja: 'その他' }, // プロパティグループ: その他
 	'Common': { en: 'Common', ja: '共通' }, // プロパティグループ: 共通
+	'Target': { en: 'Target', ja: 'ターゲット' }, // プロパティグループ: ターゲット
 	'Toggle property panel': { en: 'Properties', ja: 'プロパティ' }, // サブパネルトグルボタンラベル
+	// オブジェクトリポジトリ連携状態
+	'Linked': { en: 'Linked', ja: 'リンク済み' }, // オブジェクトリポジトリ: 連携あり
+	'Not linked': { en: 'Not linked', ja: '未リンク' }, // オブジェクトリポジトリ: 連携なし
 };
 
 // === 翻訳関数 ===

--- a/packages/shared/parser/xaml-parser.ts
+++ b/packages/shared/parser/xaml-parser.ts
@@ -565,7 +565,8 @@ export class XamlParser {
       'AssignOperation', // MultipleAssign内の代入操作（プロパティとして処理済み）
       'TargetApp',
       'TargetAnchorable',
-      'Target'
+      'Target',
+      'VerifyExecutionOptions' // NClick等の検証オプション（プロパティとして処理済み）
     ];
 
     // プレフィックスでチェック（sap:, scg:, x: など）

--- a/packages/shared/renderer/property-config.ts
+++ b/packages/shared/renderer/property-config.ts
@@ -44,18 +44,19 @@ const DEFAULT_MAIN_PROPERTIES = ['To', 'Value', 'Condition', 'Selector', 'Messag
 /** アクティビティ別の設定マップ */
 const ACTIVITY_CONFIGS: Record<string, ActivityPropertyConfig> = { // アクティビティタイプ → 設定
   'NApplicationCard': { // モダンアプリケーションカード
-    mainProperties: ['TargetApp'], // メイン: アプリ名（特殊レンダリング）
+    mainProperties: ['TargetApp'], // メイン: URL（特殊レンダリング）
     subGroups: [ // サブパネル内のグループ
+      { label: () => t('Target'), properties: ['Selector', 'ObjectRepository'] }, // ターゲットグループ: セレクター・リポジトリ状態
       { label: () => t('Input'), properties: ['AttachMode'] }, // 入力グループ
-      { label: () => t('Options'), properties: ['HealingAgentBehavior', 'Version'] }, // オプショングループ
-      { label: () => t('Misc'), properties: ['ScopeGuid'] }, // その他グループ
+      { label: () => t('Options'), properties: ['InteractionMode', 'HealingAgentBehavior'] }, // オプショングループ
     ],
   },
   'NClick': { // モダンクリック
     mainProperties: ['Target'], // メイン: ターゲット
-    subGroups: [ // サブパネル内のグループ
-      { label: () => t('Input'), properties: ['ClickType', 'MouseButton', 'KeyModifiers'] }, // 入力グループ
-      { label: () => t('Options'), properties: ['ActivateBefore', 'InteractionMode'] }, // オプショングループ
+    subGroups: [ // サブパネル内のグループ（UiPath Studioのプロパティパネル準拠）
+      { label: () => t('Target'), properties: ['FullSelectorArgument', 'FuzzySelectorArgument', 'ObjectRepository'] }, // ターゲットグループ: セレクター・リポジトリ状態
+      { label: () => t('Input'), properties: ['ClickType', 'CursorMotionType', 'MouseButton'] }, // 入力グループ
+      { label: () => t('Options'), properties: ['ActivateBefore', 'AlterDisabledElement', 'InteractionMode', 'KeyModifiers'] }, // オプショングループ
     ],
   },
   'NTypeInto': { // モダン文字入力
@@ -101,6 +102,10 @@ export function getSubProperties( // サブプロパティ抽出関数
     if (isHiddenProperty(key)) continue; // メタデータはスキップ
     if (key === 'DisplayName') continue; // 表示名はヘッダーに表示済み
     if (key === 'AssignOperations') continue; // MultipleAssignの専用プロパティはスキップ
+    if (key === 'ScopeGuid' || key === 'ScopeIdentifier') continue; // スコープGUIDは内部用（表示不要）
+    if (key === 'Version') continue; // バージョンは内部用（表示不要）
+    if (key === 'Body') continue; // Bodyはアクティビティコンテナ（表示不要）
+    if (key === 'VerifyOptions') continue; // 検証オプションは複合オブジェクト（表示不要）
     result[key] = value; // サブプロパティとして追加
   }
 


### PR DESCRIPTION
## 概要

NApplicationCard・NClickアクティビティのプロパティ表示をUiPath Studio準拠に改善。

## 変更内容

### NApplicationCard
- メインプロパティにブラウザURLを表示
- サブプロパティにセレクター・オブジェクトリポジトリ連携状態を追加
- 不要プロパティ（ScopeGuid, Version, Body）を非表示化

### NClick
- サブプロパティをUiPath Studioのプロパティパネル準拠に変更
  - Target: 厳密セレクター・あいまいセレクター・オブジェクトリポジトリ状態
  - Input: クリック種別・カーソル移動タイプ・マウスボタン
  - Options: 事前アクティブ化・無効な要素を変更・操作モード・キー修飾子
- TargetのJSONダンプ表示を解消
- VerifyExecutionOptionsが子アクティビティとして表示される問題を修正

### 共通
- i18nにURL・セレクター・リポジトリ状態等の翻訳を追加
- diff-rendererにNApplicationCardの差分表示サポートを追加

Closes #189