### PR TITLE
dev-buildスキルのCWD永続変更問題を修正

### DIFF
--- a/.claude/skills/dev-build/SKILL.md
+++ b/.claude/skills/dev-build/SKILL.md
@@ -34,11 +34,11 @@ git branch --show-current
 ### 2. ビルド
 
 ```bash
-npm run build:shared && cd packages/github-extension && npx webpack --mode development
+npm run build:shared && (cd packages/github-extension && npx webpack --mode development)
 ```
 
 - `npm run build:shared` はプロジェクトルート（現在のディレクトリ）から実行
-- `npx webpack` は `cd packages/github-extension` で移動してから実行
+- `npx webpack` はサブシェル内で `cd packages/github-extension` してから実行（CWD を変更しない）
 
 **注意**: `npm run dev:github` はwatchモードのため、スキルでは `npx webpack --mode development` を直接実行して1回だけビルドする。
 


### PR DESCRIPTION
## 概要

`/dev-build` スキルのビルドコマンドで `cd packages/github-extension` が Bash ツールの CWD を永続的に変更してしまう問題を修正。

## 変更内容

- ビルドコマンドの `cd` をサブシェル `()` で囲み、CWD の変更がスコープ内に閉じるようにした
- これにより `/gh-finish` フローで Worktree 削除後に CWD が無効化されるエラーが解消される

## 修正箇所

- `.claude/skills/dev-build/SKILL.md`: ビルドコマンドをサブシェルで囲む

Closes #197