### PR TITLE
差分表示の不要プロパティをサブパネルに移動し、diff精度を改善

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -8,7 +8,7 @@ export { SequenceRenderer } from './renderer/sequence-renderer'; // Sequenceレ�
 export type { ScreenshotPathResolver } from './renderer/sequence-renderer'; // スクリーンショットパスリゾルバー型
 export { TreeViewRenderer } from './renderer/tree-view-renderer'; // ツリービュークラス
 export { DiffRenderer } from './renderer/diff-renderer'; // 差分表示レンダリングクラス
-export { isHiddenProperty, getActivityPropertyConfig, getSubProperties, hasSubPanel, isDefinedActivity } from './renderer/property-config'; // プロパティ分類関数
+export { isHiddenProperty, getActivityPropertyConfig, getSubProperties, hasSubPanel, isDefinedActivity, categorizeDiffChanges } from './renderer/property-config'; // プロパティ分類関数
 export type { PropertyGroup, ActivityPropertyConfig } from './renderer/property-config'; // プロパティ分類型
 
 // i18n（国際化）のエクスポート


### PR DESCRIPTION
## 概要

差分表示（Diff View）で表示される不要なプロパティをサブプロパティパネルに移動し、メイン表示を見やすく改善しました。また、ワードレベルdiffのトークン化を改善しました。

## 変更内容

### プロパティ分類の改善
- `categorizeDiffChanges` 関数を追加し、差分プロパティをメイン表示とサブパネルに分類
- `ACTIVITY_CONFIGS` に登録済みのアクティビティは、`mainProperties` 以外をサブパネルに移動
- オブジェクト型のメインプロパティ（例: `Target`）はサブパネルに移動（展開時のノイズ防止）
- `ImageBase64` プロパティを非表示に

### diff精度の改善
- `<webctrl>` セレクター文字列を属性名・属性値単位でトークン化してdiff
- カンマ区切り値（座標等）をカンマ単位でトークン化してdiff
- 従来の文字レベル比較をトークンレベル比較に改善

### サブパネルUI
- 折りたたみ可能な「Properties ▶」パネルを差分表示に追加
- メイン変更とサブ変更を明確に分離

Closes #201